### PR TITLE
Improve CSS specificity determination

### DIFF
--- a/lib/selector.js
+++ b/lib/selector.js
@@ -26,38 +26,33 @@ function Selector (text, spec) {
 
 var specificity = function (text) {
   var parsed = parse(text);
-  var expressions = parsed.expressions;
-  var spec = [0, 0, 0, 0];
-  for (var j = 0; j < expressions.length; j++) {
-    var b = 0, c = 0, d = 0, s = [], nots = [];
-    for (var i = 0; i < expressions[j].length; i++) {
-      var expression = expressions[j][i], pseudos = expression.pseudos;
+  var expressions = parsed.expressions[0];
+  var spec = [0, 0, 0, 0], nots = [];
+  for (var i = 0; i < expressions.length; i++) {
+    var expression = expressions[i], pseudos = expression.pseudos;
 
-      // id awards a point in the second column
-      if (expression.id) b++;
+    // id awards a point in the second column
+    if (expression.id) spec[1]++;
 
-      // classes and attributes award a point each in the third column
-      if (expression.attributes) c += expression.attributes.length;
-      if (expression.classes) c += expression.classes.length;
+    // classes and attributes award a point each in the third column
+    if (expression.attributes) spec[2] += expression.attributes.length;
+    if (expression.classes) spec[2] += expression.classes.length;
 
-      // tag awards a point in the fourth column
-      if (expression.tag && expression.tag != '*') d++;
+    // tag awards a point in the fourth column
+    if (expression.tag && expression.tag != '*') spec[3]++;
 
-      // pseudos award a point each in the fourth column
-      if (pseudos) {
-        d += pseudos.length;
-        for (var p = 0; p < pseudos.length; p++) if (pseudos[p].key == 'not'){
-          nots.push(pseudos[p].value);
-          d--;
-        }
+    // pseudos award a point each in the fourth column
+    if (pseudos) {
+      spec[3] += pseudos.length;
+      for (var p = 0; p < pseudos.length; p++) if (pseudos[p].key == 'not'){
+        nots.push(pseudos[p].value);
+        spec[3]--;
       }
     }
-    s = [0, b, c, d];
-    for (var ii = nots.length; ii--;) {
-      var not = specificity(nots[ii]);
-      for (var jj = 4; jj--;) s[jj] += not[jj];
-    }
-    if (s.join('') > spec.join('')) spec = s;
+  }
+  for (var ii = nots.length; ii--;) {
+    var not = specificity(nots[ii]);
+    for (var jj = 4; jj--;) spec[jj] += not[jj];
   }
   return spec;
 }
@@ -69,6 +64,6 @@ var specificity = function (text) {
  */
 
 Selector.prototype.specificity = function () {
-  if (this.spec == null) this.spec = specificity(this.text);
+  if (this.spec) this.spec = specificity(this.text);
   return this.spec;
 }


### PR DESCRIPTION
See this comment: https://github.com/LearnBoost/juice/commit/90330700

Basically this adds support for the `:not()` pseudo and for comma separated selectors.
My version converted everything to numbers instead of arrays (which is easier to compare), so I had to adjust it a bit.

I didn't ran your tests, didn't look how to get all the tests running, but it should work. More tests can be found here: https://github.com/arian/DOM/blob/matcher-specificity/Specs/spec/specificity.js
