### PR TITLE
JSDom dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   , "dependencies": {
         "cssom": "0.2.0"
-      , "jsdom": "0.2.10"
+      , "jsdom": "0.2.14"
       , "mootools-slick-parser": "1.3.2"
     }
   , "devDependencies": {


### PR DESCRIPTION
Needed to update this for juice to work with node 0.6.17
