### PR TITLE
failing test case: YUI reset CSS

### DIFF
--- a/test/cases/before.css
+++ b/test/cases/before.css
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2010, Yahoo! Inc. All rights reserved.
+ * Code licensed under the BSD License:
+ * http://developer.yahoo.com/yui/license.html
+ * version: 3.3.0
+ * build: 3167
+ * */
+html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:text-top;}sub{vertical-align:text-bottom;}input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit;}input,textarea,select{*font-size:100%;}legend{color:#000;}

--- a/test/cases/before.html
+++ b/test/cases/before.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>hello</h1>
+  </body>
+</html>

--- a/test/cases/before.out
+++ b/test/cases/before.out
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>hello</h1>
+  </body>
+</html>


### PR DESCRIPTION
This is new as of merging @eoln 's pull request. It's not really his fault, this test case wasn't in the suite, and it's a result of updating jsdom to a newer version. I think to fix this we're going to need to update jsdom _all the way_ to the newest, and then re-evaluate this and other failed test cases.

```
/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:982
    throw new Error( "Syntax error, unrecognized expression: " + msg );
          ^
Error: Syntax error, unrecognized expression: unsupported pseudo: before
    at Function.Sizzle.error (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:982:8)
    at Sizzle.selectors.filter.PSEUDO (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:691:12)
    at matcherFromTokens (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:1144:61)
    at Sizzle.compile (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:1176:14)
    at select (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:1357:13)
    at Sizzle (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/sizzle.js:262:9)
    at Object.exports.applyQuerySelector.doc.querySelectorAll (/home/andy/dev/juice/node_modules/jsdom/lib/jsdom/selectors/index.js:16:44)
    at /home/andy/dev/juice/lib/juice.js:85:28
    at Array.forEach (native)
    at juiceDom (/home/andy/dev/juice/lib/juice.js:74:9)
```
