### PR TITLE
Make it work on Windows

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -183,7 +183,8 @@ function juiceFile(filePath, options, callback) {
   fs.readFile(filePath, 'utf8', function(err, content) {
     if (err) return callback(err);
     options = getDefaultOptions(options); // so we can mutate options without guilt
-    options.url = options.url || ("file://" + path.resolve(process.cwd(), filePath));
+    var slashes = os.platform() === 'win32' ? '\\\\' : '//';
+    options.url = options.url || ("file:" + slashes + path.resolve(process.cwd(), filePath));
     juiceContent(content, options, callback);
   });
 }


### PR DESCRIPTION
Juice didn't work for me on Windows 7 64bit. I tested the example code from the **How to use** section.

Making the slashes on `file:\\` platform dependent solved the problem.
