### PR TITLE
fix crash due to 'object does not have clone method' exception thrown

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -197,7 +197,9 @@ function inlineContent(html, css) {
   var inner = document.innerHTML;
   // free the associated memory
   // with lazily created parentWindow
-  document.parentWindow.close();
+  try {
+    document.parentWindow.close();
+  } catch (cleanupErr) {}
   return inner;
 }
 


### PR DESCRIPTION
...on Kubuntu 12/64bit VM, node 0.10.0

Situation: latest juice was installed as a dependency via npm install: npm list shows this:

```
└─┬ juice@0.3.2
  ├── batch@0.3.2
  ├─┬ commander@1.1.1
  │ └── keypress@0.1.0
  ├── cssom@0.2.5
  ├── slick@1.10.0
  └─┬ superagent@0.13.0
    ├── cookiejar@1.3.0
    ├── emitter-component@0.0.6
    ├── formidable@1.0.9
    ├── methods@0.0.1
    ├── mime@1.2.5
    └── qs@0.5.2
```

juice was invoked via

```
require('juice');
...
juice(file, callback);
```
