### PR TITLE
Provided a workaround for the JSDom issue that strips out the DOCTYPE.

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -161,7 +161,10 @@ function juiceContent(html, options, callback) {
      } catch (cleanupErr) {}
      callback(err);
     } else {
-     var inner = document.innerHTML;
+
+     // A workaround for a JSDom issue you can read about here:
+     // https://github.com/nodejitsu/docs/issues/49
+     var inner = document.doctype.toString() + document.innerHTML;
      // free the associated memory
      // with lazily created parentWindow
      try {


### PR DESCRIPTION
JSDom will strip out your DOCTYPE, and, consequently, so does Juice. This is a [known issue](https://github.com/nodejitsu/docs/issues/49) with JSDom that doesn't look like it will be resolved anytime soon. tmpvar, the creator of JSDom, suggests a workaround for solving the problem in the above link. That workaround is what I've implemented here.
