### PR TITLE
Shorthand expansion is busted

### DIFF
--- a/test/cases/shorthand.css
+++ b/test/cases/shorthand.css
@@ -1,0 +1,7 @@
+p {
+  padding-bottom: 10px;
+}
+
+#p {
+  padding: 0px;
+}

--- a/test/cases/shorthand.html
+++ b/test/cases/shorthand.html
@@ -1,0 +1,3 @@
+<html><body>
+<p id="p">woot</p>
+</body></html>

--- a/test/cases/shorthand.out
+++ b/test/cases/shorthand.out
@@ -1,0 +1,3 @@
+<html><body>
+<p id="p" style="padding: 0px;">woot</p>
+</body></html>


### PR DESCRIPTION
Here's a case where the shorthand form of `padding` behaves differently before and after inlining.

Using the styles directly, browsers set `padding-bottom: 0px` on the `<p/>`.  Juice doesn't expand `padding: 0px` to `padding-bottom`, so the `<p/>` ends up with both `padding: 0px; padding-bottom: 10px`.

Anyone else caught by this?  My only idea for fixing it is to expand shorthand properties as they're [parsed])(https://github.com/LearnBoost/juice/blob/master/lib/juice.js#L112).  This could balloon style length.  Might be worth another pass after inlining to combine styles back into shorthands where it's safe.  Thoughts?