### PR TITLE
Fix css-file read in windows

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -249,6 +249,8 @@ function getStylesData(document, options, callback) {
 }
 
 function getHrefContent(destHref, sourceHref, callback) {
+  //in windows we need to replace backslashes with slashes
+  sourceHref = sourceHref.replace(/\\/g, '/');
   var resolvedUrl = url.resolve(sourceHref, destHref);
   var parsedUrl = url.parse(resolvedUrl);
   if (parsedUrl.protocol === 'file:') {


### PR DESCRIPTION
url.resolve does not resolve correct url in windows since it doesn't
like backslashes.

If we inline following file:
````
<html>
<head>
    <link rel="stylesheet" href="css/style.css">
</head>
<body>
</body>
````

getHrefContent returns undefined in Windows, although in Linux the css-file is read just fine. This does not effect other operating systems.
