### PR TITLE
Implement creating <font> tag

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -58,7 +58,7 @@ juice.juiceFile = juiceFile;
 juice.inlineDocument = inlineDocument;
 juice.inlineContent = inlineContent;
 
-function inlineDocument(document, css) {
+function inlineDocument(document, options, css) {
   var rules = utils.parseCSS(css)
     , editedElements = []
 
@@ -128,11 +128,48 @@ function inlineDocument(document, css) {
   }
 
   function setStyleAttrs(el) {
-    var style = '';
+    var style = '',
+        fontStyle = {};
+
     for (var i in el.styleProps) {
-      style += el.styleProps[i].toString() + ' ';
-    }
+
+      // if has no children, insert the 'font' tag in here
+      if ( options.createFontTags ) {
+        if ( i == 'font-family' ) {
+          fontStyle['face'] = el.styleProps[i].value; 
+        } else if ( i == 'color' ) {
+          fontStyle['color'] = el.styleProps[i].value; 
+        } else if ( i == 'font-size' ) {
+          var thisVal = el.styleProps[i].value,
+              thisInPx = (thisVal.match('px')) ? parseInt(thisVal) :
+                (thisVal.match('em')) ? parseInt(thisVal) * 16 :
+                  16;
+          fontStyle['size'] = Math.ceil( Math.pow( thisInPx - 6, .75 ) / 2 );
+        } else {
+          style += el.styleProps[i].toString() + ' ';
+        }
+      } else {
+        style += el.styleProps[i].toString() + ' ';
+      }
+    } 
     el.setAttribute('style', style.trim());
+
+    if (Object.keys(fontStyle).length && el.innerHTML.trim().length) {
+
+      var childNodes = [];
+      while (el.firstChild) {
+        childNodes.push( el.removeChild( el.firstChild ) );
+      }
+
+      var fontTag = el.appendChild( document.createElement('font') );
+      for (var attr in fontStyle) { 
+        fontTag.setAttribute(''+attr, fontStyle[attr]); 
+      }
+
+      childNodes.forEach(function(node) { 
+        fontTag.appendChild(node); 
+      });
+    }
   }
 }
 
@@ -141,7 +178,7 @@ function juiceDocument(document, options, callback) {
   options = getDefaultOptions(options);
   extractCssFromDocument(document, options, function(err, css) {
     css += "\n" + options.extraCss;
-    inlineDocumentWithCb(document, css, callback);
+    inlineDocumentWithCb(document, css, options, callback);
   });
 }
 
@@ -179,6 +216,7 @@ function getDefaultOptions(options) {
     removeStyleTags: true,
     applyLinkTags: true,
     removeLinkTags: true,
+    createFontTags: false
   }, options);
 }
 
@@ -221,9 +259,9 @@ function juice (arg1, arg2, arg3) {
   juiceFile(arg1, options, callback);
 }
 
-function inlineDocumentWithCb(document, css, callback) {
+function inlineDocumentWithCb(document, css, options, callback) {
   try {
-    inlineDocument(document, css);
+    inlineDocument(document, options, css);
     callback();
   } catch (err) {
     callback(err);


### PR DESCRIPTION
As I brought up in #65:

Adds an additional option to the `options` object, called
`createFontTags`. If the option is set to "true", then while looping
through the document elements to create style props, changes the
behavior of the `setStyleAttrs` method:
- if the style attribute contains any of `font-family`, `font-size`, or
  `color`, those elements are not added to the style attribute, but
  instead are added to a <font> tag which is wrapped around the
  element's innerHTML.
