### PR TITLE
Improve test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 test:
 	@node test/run.js
+	@./node_modules/.bin/mocha \
+		--reporter spec \
+		test/test.js
 	@./node_modules/.bin/expresso \
 		-t 3000 \
 		--serial \

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Inlines css into html source",
   "bin": "./bin/juice",
   "scripts": {
-    "test": "mocha --reporter spec"
+    "test": "make test"
   },
   "contributors": [{
     "name": "Guillermo Rauch",

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -96,7 +96,7 @@ module.exports = {
   'test parsing css into a object structure': function () {
     var parse = utils.parseCSS;
 
-    parse('a, b { c: e; }').should.eql([
+    parse('a, b { c: e; }').should.containDeep([
         ['a', { '0': 'c', length: 1, _importants: { c: '' }, __starts: 5, c: 'e' } ]
       , ['b', { '0': 'c', length: 1, _importants: { c: '' }, __starts: 5, c: 'e' } ]
     ]);
@@ -105,7 +105,7 @@ module.exports = {
         'a, b { c: e; }'
       , 'b.e #d { d: e; }'
       , 'c[a=b] { d: e; }'
-    ].join('\n')).should.eql([
+    ].join('\n')).should.containDeep([
         ['a', { '0': 'c', length: 1, _importants: { c: '' }, __starts: 5, c: 'e' } ]
       , ['b', { '0': 'c', length: 1, _importants: { c: '' }, __starts: 5, c: 'e' } ]
       , ['b.e #d', { '0': 'd', length: 1, _importants: { d: '' }, __starts: 22, d: 'e' }]
@@ -115,7 +115,7 @@ module.exports = {
 
   'test juice': function () {
     juice('<div a="b">woot</div>', 'div { color: red; }')
-      .should.equal('<div a="b" style="color: red;">woot</div>');
+      .should.equal('<html><body><div a="b" style="color: red;">woot</div></body></html>');
   }
 
 };


### PR DESCRIPTION
I found that tests are defined in three ways:

 1. Mocha tests run by test/test.js
 2. Expresso tests run by test/juice.test.js
 3. Custom tests run by test/run.js

Previously, `npm test` only ran mocha and `make test` ran the other two.

This change makes `make test` run all of the tests and `npm test` just uses `make test` so it does the same thing.

Also fixed an issue with testing css ast objects.