### PR TITLE
Add option to add !important to all styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Output:
    - `url` - how to resolve hrefs. Defaults to using `filePath`. If you want
      to override, be sure your `url` has the protocol at the beginning, e.g.
      `http://` or `file://`.
+   -`importantEverything`: Add `important!` to *all* styles. This is
+     helpful for email clients that have their own `important!` styles
+     (e.g., Gmail's `a { color: #7a1026 !important; }` style).
  * `callback(err, html)`
    - `err` - `Error` object or `null`.
    - `html` - contains the html from `filePath`, with potentially `<style>` and

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -134,7 +134,7 @@ function inlineDocument(document, css, options) {
   }
 
   function setStyleAttrs(el) {
-    var imp = options.importantEverything ? " !important" : "";
+    var imp = options && options.importantEverything ? " !important" : "";
     var style = [];
     for (var i in el.styleProps) {
       style.push(el.styleProps[i].prop + ": " + el.styleProps[i].value.replace(/["]/g, "'") + imp + ";");

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -134,9 +134,10 @@ function inlineDocument(document, css, options) {
   }
 
   function setStyleAttrs(el) {
+    var imp = options.importantEverything ? " !important" : "";
     var style = [];
     for (var i in el.styleProps) {
-      style.push(el.styleProps[i].prop + ": " + el.styleProps[i].value.replace(/["]/g, "'") + ";");
+      style.push(el.styleProps[i].prop + ": " + el.styleProps[i].value.replace(/["]/g, "'") + imp + ";");
     }
     // sorting will arrange styles like padding: before padding-bottom: which will preserve the expected styling
     style = style.sort( function ( a, b )

--- a/test/cases/juice-content/important-everything.html
+++ b/test/cases/juice-content/important-everything.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <style>
+      a { font-family: bold }
+    </style>
+</head>
+<body>
+<a>hello</a>
+</body>
+</html>

--- a/test/cases/juice-content/important-everything.json
+++ b/test/cases/juice-content/important-everything.json
@@ -1,0 +1,5 @@
+{
+    "url": "./",
+    "removeStyleTags": true,
+    "importantEverything": true
+}

--- a/test/cases/juice-content/important-everything.out
+++ b/test/cases/juice-content/important-everything.out
@@ -1,0 +1,8 @@
+<html>
+<head>
+    
+</head>
+<body>
+<a style="font-family: bold !important;">hello</a>
+</body>
+</html>


### PR DESCRIPTION
Helpful for email clients that have their own `important!` styles (e.g., Gmail's `a { color: #7a1026 !important; }` style).