### PR TITLE
Remove support for Node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "email": "npm@fgribreau.com"
   }],
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   },
   "dependencies": {
     "cssom": "0.3.0",


### PR DESCRIPTION
Installation fails on 0.8 because some dependencies require Node 0.10 or greater in package.engines.