### PR TITLE
Add options argument to juice.inlineContent

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -224,9 +224,9 @@ function juiceFile(filePath, options, callback) {
   });
 }
 
-function inlineContent(html, css) {
+function inlineContent(html, css, options) {
   var document = utils.jsdom(html);
-  inlineDocument(document, css, {});
+  inlineDocument(document, css, options);
   var inner = utils.docToString(document);
   // free the associated memory
   // with lazily created parentWindow


### PR DESCRIPTION
Allow passing options when using juice.inlineContent()