### PR TITLE
Move resource inlining to external library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -5,6 +5,8 @@
  * MIT Licensed
  */
 
+var juice = function () {};
+
 module.exports = juice;
 
 /**
@@ -16,14 +18,9 @@ var utils = require('./utils')
   , Property = require('./property')
   , packageJson = require('../package')
   , fs = require('fs')
-  , Batch = require('batch')
-  , url = require('url')
-  , superagent = require('superagent')
-  , path = require('path')
   , assert = require('assert')
-  , os = require('os')
   , styleSelector = new Selector('<style attribute>', [1, 0, 0, 0])
-  , importantSelector = new Selector('<!important>', [2, 0, 0, 0])
+  , importantSelector = new Selector('<!important>', [2, 0, 0, 0]);
 
 /**
  * Package version
@@ -147,7 +144,7 @@ function inlineDocument(document, css, options) {
     } );
     el.setAttribute('style', style.join(' '));
   }
-  
+
   function setWidthAttrs(el) {
     if (juice.widthElements.indexOf(el.nodeName) > -1) {
       for (var i in el.styleProps) {
@@ -162,43 +159,41 @@ function inlineDocument(document, css, options) {
 }
 
 function juiceDocument(document, options, callback) {
-  assert.ok(options.url, "options.url is required");
   options = getDefaultOptions(options);
-  extractCssFromDocument(document, options, function(err, css) {
-    if (err) {
-      return callback(err);
-    }
-
-    css += "\n" + options.extraCss;
-    inlineDocumentWithCb(document, css, options, callback);
-  });
+  var css = extractCssFromDocument(document, options);
+  css += "\n" + options.extraCss;
+  inlineDocumentWithCb(document, css, options, callback);
 }
 
 function juiceContent(html, options, callback) {
-  assert.ok(options.url, "options.url is required");
   options = getDefaultOptions(options);
-  // hack to force jsdom to see this argument as html content, not a url
-  // or a filename. https://github.com/tmpvar/jsdom/issues/554
-  html += "\n";
-  var document = utils.jsdom(html);
-  juiceDocument(document, options, function(err) {
-    if (err) {
-      // free the associated memory
-      // with lazily created parentWindow
-      try {
-       document.parentWindow.close();
-      } catch (cleanupErr) {}
-      callback(err);
-    } else {
-      var inner = utils.docToString(document);
-      // free the associated memory
-      // with lazily created parentWindow
-      try {
-        document.parentWindow.close();
-      } catch (cleanupErr) {}
-      callback(null, inner);
+
+  var onDom = function(err, document) {
+    if(err){
+      return callback(err);
     }
-  });
+
+    juiceDocument(document, options, function(err) {
+      if (err) {
+        // free the associated memory
+        // with lazily created parentWindow
+        try {
+         document.parentWindow.close();
+        } catch (cleanupErr) {}
+        callback(err);
+      } else {
+        var inner = utils.docToString(document);
+        // free the associated memory
+        // with lazily created parentWindow
+        try {
+          document.parentWindow.close();
+        } catch (cleanupErr) {}
+        callback(null, inner);
+      }
+    });
+  };
+
+  utils.jsdom(html, options, onDom);
 }
 
 function getDefaultOptions(options) {
@@ -218,38 +213,26 @@ function juiceFile(filePath, options, callback) {
   fs.readFile(filePath, 'utf8', function(err, content) {
     if (err) return callback(err);
     options = getDefaultOptions(options); // so we can mutate options without guilt
-    var slashes = os.platform() === 'win32' ? '\\\\' : '//';
-    options.url = options.url || ("file:" + slashes + path.resolve(process.cwd(), filePath));
     juiceContent(content, options, callback);
   });
 }
 
-function inlineContent(html, css) {
-  var document = utils.jsdom(html);
-  inlineDocument(document, css, {});
-  var inner = utils.docToString(document);
-  // free the associated memory
-  // with lazily created parentWindow
-  try {
-    document.parentWindow.close();
-  } catch (cleanupErr) {}
-  return inner;
-}
+function inlineContent(html, css, options, callback) {
+  var onDom = function(err, document){
+    if(err){
+      return callback(err);
+    }
+    inlineDocument(document, css, {});
+    var inner = utils.docToString(document);
+    // free the associated memory
+    // with lazily created parentWindow
+    try {
+      document.parentWindow.close();
+    } catch (cleanupErr) {}
+    callback(null, inner);
+  }
 
-/**
- * Inlines the CSS specified by `css` into the `html`
- *
- * @param {String} html
- * @param {String} css
- * @api public
- */
-
-function juice (arg1, arg2, arg3) {
-  // legacy behavior
-  if (typeof arg2 === 'string') return inlineContent(arg1, arg2);
-  var options = arg3 ? arg2 : {};
-  var callback = arg3 ? arg3 : arg2;
-  juiceFile(arg1, options, callback);
+  utils.jsdom(html, options, onDom);
 }
 
 function inlineDocumentWithCb(document, css, options, callback) {
@@ -261,7 +244,7 @@ function inlineDocumentWithCb(document, css, options, callback) {
   }
 }
 
-function getStylesData(document, options, callback) {
+function getStylesData(document, options) {
   var results = [];
   var stylesList = document.getElementsByTagName("style");
   var i, styleDataList, styleData, styleElement;
@@ -269,8 +252,7 @@ function getStylesData(document, options, callback) {
     styleElement = stylesList[i];
     styleDataList = styleElement.childNodes;
     if (styleDataList.length !== 1) {
-      callback(new Error("empty style element"));
-      return;
+      continue
     }
     styleData = styleDataList[0].data;
     if ( options.applyStyleTags ) results.push( styleData );
@@ -287,69 +269,12 @@ function getStylesData(document, options, callback) {
     	}
     }
   }
-  callback(null, results);
-}
-
-function getHrefContent(destHref, sourceHref, callback) {
-  if (url.parse(sourceHref).protocol === 'file:' && destHref[0] === '/') {
-    destHref = destHref.slice(1);
-  }
-  var resolvedUrl = url.resolve(sourceHref, destHref);
-  var parsedUrl = url.parse(resolvedUrl);
-  if (parsedUrl.protocol === 'file:') {
-    fs.readFile(decodeURIComponent(parsedUrl.pathname), 'utf8', callback);
-  } else {
-    getRemoteContent(resolvedUrl, callback);
-  }
-}
-
-function getRemoteContent(remoteUrl, callback) {
-  superagent.get(remoteUrl).buffer().end(function(err, resp) {
-    if (err) {
-      callback(err);
-    } else if (resp.ok) {
-      callback(null, resp.text);
-    } else {
-      callback(new Error("GET " + remoteUrl + " " + resp.status));
-    }
-  });
-}
-
-function getStylesheetList(document, options) {
-  var results = [];
-  var linkList = document.getElementsByTagName("link");
-  var link, i, j, attr, attrs;
-  for (i = 0; i < linkList.length; ++i) {
-    link = linkList[i];
-    attrs = {};
-    for (j = 0; j < link.attributes.length; ++j) {
-      attr = link.attributes[j];
-      attrs[attr.name.toLowerCase()] = attr.value;
-    }
-    if (attrs.rel && attrs.rel.toLowerCase() === 'stylesheet') {
-      if (options.applyLinkTags) results.push(attrs.href);
-      if (options.removeLinkTags) link.parentNode.removeChild(link);
-    }
-  }
   return results;
 }
 
-function extractCssFromDocument(document, options, callback) {
-  var batch = new Batch();
-  batch.push(function(callback) { getStylesData(document, options, callback); });
-  getStylesheetList(document, options).forEach(function(stylesheetHref) {
-    batch.push(function(callback) {
-      getHrefContent(stylesheetHref, options.url, callback);
-    });
-  });
-  batch.end(function(err, results) {
-    if (err) return callback(err);
-    var stylesData = results.shift();
-    results.forEach(function(content) {
-      stylesData.push(content);
-    });
-    var css = stylesData.join("\n");
-    callback(null, css);
-  });
+function extractCssFromDocument(document, options) {
+  var results = getStylesData(document, options);
+  var css = results.join("\n");
+  return css;
 }
 

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -18,6 +18,7 @@ var utils = require('./utils')
   , Property = require('./property')
   , packageJson = require('../package')
   , fs = require('fs')
+  , path = require('path')
   , assert = require('assert')
   , styleSelector = new Selector('<style attribute>', [1, 0, 0, 0])
   , importantSelector = new Selector('<!important>', [2, 0, 0, 0]);
@@ -138,9 +139,9 @@ function inlineDocument(document, css, options) {
     // sorting will arrange styles like padding: before padding-bottom: which will preserve the expected styling
     style = style.sort( function ( a, b )
     {
-    	var aProp = a.split( ':' )[0];
-    	var bProp = b.split( ':' )[0];
-    	return ( aProp > bProp ? 1 : aProp < bProp ? -1 : 0 );
+      var aProp = a.split( ':' )[0];
+      var bProp = b.split( ':' )[0];
+      return ( aProp > bProp ? 1 : aProp < bProp ? -1 : 0 );
     } );
     el.setAttribute('style', style.join(' '));
   }
@@ -213,6 +214,10 @@ function juiceFile(filePath, options, callback) {
   fs.readFile(filePath, 'utf8', function(err, content) {
     if (err) return callback(err);
     options = getDefaultOptions(options); // so we can mutate options without guilt
+    if(!options.relativeTo){
+      var rel = path.dirname(path.relative(process.cwd(),filePath));
+      options.relativeTo = rel;
+    };
     juiceContent(content, options, callback);
   });
 }
@@ -258,15 +263,15 @@ function getStylesData(document, options) {
     if ( options.applyStyleTags ) results.push( styleData );
     if ( options.removeStyleTags )
     {
-    	if ( options.preserveMediaQueries )
-    	{
-    		var mediaQueries = utils.getMediaQueryText( styleElement.childNodes[0].nodeValue );
-    		styleElement.childNodes[0].nodeValue = mediaQueries;
-    	}
-    	else
-    	{
-    		styleElement.parentNode.removeChild( styleElement );
-    	}
+      if ( options.preserveMediaQueries )
+      {
+        var mediaQueries = utils.getMediaQueryText( styleElement.childNodes[0].nodeValue );
+        styleElement.childNodes[0].nodeValue = mediaQueries;
+      }
+      else
+      {
+        styleElement.parentNode.removeChild( styleElement );
+      }
     }
   }
   return results;

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var parser = require('slick').parse
+var parser = require('slick').parse;
 
 /**
  * Module exports.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ var fs = require('fs')
   , jsdom = require('jsdom')
   , own = {}.hasOwnProperty
   , os = require('os')
-  , inline = require('html-resource-inline');
+  , inline = require('web-resource-inliner');
 
 /**
  * Returns an array of the selectors.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,10 +165,14 @@ exports.docToString = function (doc) {
   var contents = doc.innerHTML;
 
   // normalize line endings
-  contents = contents.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+  contents = exports.normalizeLineEndings(contents);
 
   return (doctype === null ? '' : doctype) + contents;
-}
+};
+
+exports.normalizeLineEndings = function (text){
+  return text.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+};
 
 /**
  * Converts to array

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,8 @@ var fs = require('fs')
   , cssom = require('cssom')
   , jsdom = require('jsdom')
   , own = {}.hasOwnProperty
-  , os = require('os');
+  , os = require('os')
+  , inline = require('html-resource-inline');
 
 /**
  * Returns an array of the selectors.
@@ -135,21 +136,38 @@ exports.getMediaQueryText = function ( css )
  * api public
  */
 
-exports.jsdom = function (html) {
-  return jsdom.html(html, null, {
-    features: {
-        QuerySelector: ['1.0']
-      , FetchExternalResources: false
-      , ProcessExternalResources: false
-      , MutationEvents: false
-    }
-  });
+exports.jsdom = function (html, inlineOptions, callback) {
+
+  var onInlined = function (err, html)
+  {
+    // hack to force jsdom to see this argument as html content, not a url
+    // or a filename. https://github.com/tmpvar/jsdom/issues/554
+    html += "\n";
+
+    var document = jsdom.html(html, null, {
+      features: {
+          QuerySelector: ['1.0']
+        , FetchExternalResources: false
+        , ProcessExternalResources: false
+        , MutationEvents: false
+      }
+    });
+
+    callback(null, document);
+  };
+
+  var options = exports.extend({fileContent: html}, inlineOptions);
+  inline.html(options, onInlined);
 };
 
 exports.docToString = function (doc) {
   var doctype = doc.doctype;
+  var contents = doc.innerHTML;
 
-  return (doctype === null ? '' : doctype) + doc.innerHTML;
+  // normalize line endings
+  contents = contents.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+
+  return (doctype === null ? '' : doctype) + contents;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,31 +6,37 @@
   "scripts": {
     "test": "mocha --reporter spec"
   },
-  "contributors": [{
-    "name": "Guillermo Rauch",
-    "email": "guillermo@learnboost.com"
-  }, {
-    "name": "Arian Stolwijk",
-    "email": "arian@aryweb.nl"
-  }, {
-    "name": "Paweł Marzec",
-    "email": "rork@cojestgrane.pl"
-  }, {
-    "name": "Andrew Kelley",
-    "email": "superjoe30@gmail.com"
-  }, {
-    "name": "Francois-Guillaume Ribreau",
-    "email": "npm@fgribreau.com"
-  }],
+  "contributors": [
+    {
+      "name": "Guillermo Rauch",
+      "email": "guillermo@learnboost.com"
+    },
+    {
+      "name": "Arian Stolwijk",
+      "email": "arian@aryweb.nl"
+    },
+    {
+      "name": "Paweł Marzec",
+      "email": "rork@cojestgrane.pl"
+    },
+    {
+      "name": "Andrew Kelley",
+      "email": "superjoe30@gmail.com"
+    },
+    {
+      "name": "Francois-Guillaume Ribreau",
+      "email": "npm@fgribreau.com"
+    }
+  ],
   "engines": {
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "cssom": "0.3.0",
-    "jsdom": "0.9.0",
-    "batch": "0.5.1",
-    "superagent": "~0.20.0",
+    "batch": "0.5.2",
     "commander": "2.3.0",
+    "cssom": "0.3.0",
+    "html-resource-inline": "^1.0.0",
+    "jsdom": "0.9.0",
     "slick": "1.12.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "batch": "0.5.2",
     "commander": "2.3.0",
     "cssom": "0.3.0",
-    "html-resource-inline": "^1.0.0",
+    "web-resource-inliner": "1.0.0",
     "jsdom": "0.9.0",
     "slick": "1.12.1"
   },

--- a/test/cases/identical-important.out
+++ b/test/cases/identical-important.out
@@ -1,1 +1,2 @@
-<html><body><div style="color: blue;"></div></body></html>
+<html><body><div style="color: blue;">
+</div></body></html>

--- a/test/cases/jsdom.out
+++ b/test/cases/jsdom.out
@@ -1,1 +1,2 @@
-<html><body></body></html>
+<html><body>
+</body></html>

--- a/test/cases/regression-media.out
+++ b/test/cases/regression-media.out
@@ -1,3 +1,4 @@
 <html><body><a href="#" style="color: green;">Test</a>
 <p style="color: green;">Test</p>
+
 </body></html>

--- a/test/run.js
+++ b/test/run.js
@@ -1,180 +1,61 @@
 
-/*!
- * Test runner based on Stylus test runner.
- */
-
-/**
- * Module dependencies.
- */
-
 var juice = require('../')
   , basename = require('path').basename
   , fs = require('fs')
+  , assert = require('assert');
 
-/**
- * Test count.
- */
-
-var count = 0;
-
-/**
- * Failure count.
- */
-
-var failures = 0;
-
-/**
- * Test the given `test`.
- *
- * @param {String} test
- * @param {Function} fn
- */
-
-function test (testName, fn, options) {
-  var base = __dirname + '/cases/' + testName
-    , html =  read(base + '.html')
-    , css = read( base + '.css' )
-    , config = options ? JSON.parse( read( base + '.json' ) ) : null
-
-  function read (file) {
-    return fs.readFileSync(file, 'utf8');
-  }
-
-  var onDone = function ( err, actual )
-  {
-  	var expected = read( base + '.out' );
-
-  	if ( actual.trim() === expected.trim() )
-  	{
-  		fn();
-  	} else
-  	{
-  		fn( actual, expected );
-  	}
-  };
-
-  if ( config === null )
-  {
-  	// use the legacy invocation to test backward compatibility
-  	var actual = juice( html, css );
-  	onDone( null, actual );
-  }
-  else
-  {
-  	juice.juiceContent( html, config, onDone );
-  }
-
-  return testName;
-}
 
 /**
  * Auto-load and run tests.
  */
 
-fs.readdir( __dirname + '/cases', function ( err, files ) {
-  if ( err ) throw err;
-  var tests = [];
-
-  files.forEach( function ( file )
-  {
-    if ( /\.html$/.test( file ) ) {
-      ++count;
-      tests.push( { basename: basename( file, '.html' ) } );
-    }
-  } );
-
-  fs.readdir( __dirname + '/cases/juice-content', function ( err, files )
-  {
-    if ( err ) throw err;
-
-    files.forEach( function ( file )
-    {
-      if ( /\.html$/.test( file ) ) {
-        ++count;
-        tests.push( { basename: 'juice-content/' + basename( file, '.html' ), options: true } );
-      }
-    } );
-
-    nextTest( tests );
-  } );
-} );
-
-
-function nextTest( tests )
-{
-  curr = tests.shift();
-  if ( !curr ) return done();
-  process.stderr.write( '    \033[90m' + curr.basename + '\033[0m' );
-  test( curr.basename, function ( actual, expected )
-  {
-    if ( actual ) {
-      ++failures;
-      console.error( '\r  \033[31m✖\033[0m \033[90m' + curr.basename + '\033[0m\n' );
-      diff( actual, expected );
-      console.error();
-    } else {
-      console.error( '\r  \033[36m✔\033[0m \033[90m' + curr.basename + '\033[0m' );
-    }
-    nextTest( tests );
-  }, curr.options );
-}
-
-/**
- * Diff `actual` / `expected`.
- *
- * @param {String} actual
- * @param {String} expected
- */
-
-function diff (actual, expected) {
-  actual = actual.split('\n');
-  expected = expected.split('\n');
-  var len = largestLineIn(expected);
-
-  expected.forEach(function(line, i){
-    if (!line.length && i === expected.length - 1) return;
-    var other = actual[i]
-      , pad = len - line.length;
-    pad = (new Array(++pad)).join(' ');
-    var same = line === other;
-    if (same) {
-      console.error('  %d| %j%s | %j', i+1, line, pad, other);
-    } else {
-      console.error('  \033[31m%d| %j%s | %j\033[0m', i+1, line, pad, other);
-    }
-  });
-}
-
-/**
- * Return the length of the largest line in `lines`.
- *
- * @param {Array} lines
- * @return {Number}
- */
-
-function largestLineIn(lines) {
-  return lines.reduce(function(n, line){
-    return Math.max(n, line.length);
-  }, 0);
-}
-
-/**
- * Done!!!
- */
-
-function done () {
-  console.log();
-  console.log(
-      '  \033[90mcompleted\033[0m' +
-      ' \033[32m%d\033[0m' +
-      ' \033[90mtests\033[0m', count);
-
-  if (failures) {
-    console.error('  \033[90mfailed\033[0m' +
-        ' \033[31m%d\033[0m' +
-        ' \033[90mtests\033[0m', failures);
-    process.exit(failures);
+var files = fs.readdirSync( __dirname + '/cases' );
+files.forEach(function(file) {
+  if ( /\.html$/.test( file ) ) {
+    var name = basename( file, '.html' );
+    it(name, test(name, false));
   }
+});
 
-  console.log();
+var optionFiles = fs.readdirSync( __dirname + '/cases/juice-content' );
+
+optionFiles.forEach(function(file) {
+  if ( /\.html$/.test( file ) ) {
+    var name = 'juice-content/' + basename( file, '.html' );
+    it(name, test(name, true));
+  }
+});
+
+function read (file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+function test (testName, options) {
+  var base = __dirname + '/cases/' + testName
+    , html =  read(base + '.html')
+    , css = read( base + '.css' )
+    , config = options ? JSON.parse( read( base + '.json' ) ) : null;
+
+    options = {relativeTo: 'test/cases/'};
+
+  return function(done) {
+    var onJuiced = function ( err, actual )
+    {
+      if(err){
+        return done(err);
+      }
+      var expected = read( base + '.out');
+      assert.equal(actual.trim(), expected.trim());
+      done();
+    };
+
+    if ( config === null )
+    {
+      juice.inlineContent( html, css, options, onJuiced );
+    }
+    else
+    {
+      juice.juiceContent( html, config, onJuiced );
+    }
+  };
 }

--- a/test/run.js
+++ b/test/run.js
@@ -36,7 +36,7 @@ function test (testName, options) {
     , css = read( base + '.css' )
     , config = options ? JSON.parse( read( base + '.json' ) ) : null;
 
-    options = {relativeTo: 'test/cases/'};
+    options = {};
 
   return function(done) {
     var onJuiced = function ( err, actual )

--- a/test/run.js
+++ b/test/run.js
@@ -1,5 +1,6 @@
 
 var juice = require('../')
+  , utils = require('../lib/utils')
   , basename = require('path').basename
   , fs = require('fs')
   , assert = require('assert');
@@ -36,7 +37,7 @@ function test (testName, options) {
     , css = read( base + '.css' )
     , config = options ? JSON.parse( read( base + '.json' ) ) : null;
 
-    options = {};
+  options = {};
 
   return function(done) {
     var onJuiced = function ( err, actual )
@@ -44,18 +45,18 @@ function test (testName, options) {
       if(err){
         return done(err);
       }
-      var expected = read( base + '.out');
-      assert.equal(actual.trim(), expected.trim());
+      var expected = read(base + '.out');
+      assert.equal(actual.trim(), utils.normalizeLineEndings(expected.trim()));
       done();
     };
 
     if ( config === null )
     {
-      juice.inlineContent( html, css, options, onJuiced );
+      juice.inlineContent(html, css, options, onJuiced);
     }
     else
     {
-      juice.juiceContent( html, config, onJuiced );
+      juice.juiceContent(html, config, onJuiced);
     }
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 /*globals describe:false it:false*/
 var juice = require('../')
+  , utils = require('../lib/utils')
   , path = require('path')
   , fs = require('fs')
   , Batch = require('batch')
@@ -28,7 +29,7 @@ function createIt(testName) {
     });
     batch.end(function(err, results) {
       if (err) return cb(err);
-      assert.strictEqual(results[1].trim(), results[0].trim());
+      assert.strictEqual(utils.normalizeLineEndings(results[1].trim()), results[0].trim());
       cb();
     });
   };

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var juice = require('../')
   , path = require('path')
   , fs = require('fs')
   , Batch = require('batch')
-  , assert = require('assert')
+  , assert = require('assert');
 
 var tests = [
   "doctype",
@@ -21,8 +21,7 @@ function createIt(testName) {
   return function(cb) {
     var batch = new Batch();
     batch.push(function(cb) {
-      var filePath = path.join(__dirname, "html", testName + ".in.html");
-      juice(filePath, cb);
+      juice.juiceFile(path.join(__dirname, "html", testName + ".in.html"), {relativeTo: 'test/html/'}, cb);
     });
     batch.push(function(cb) {
       fs.readFile(path.join(__dirname, "html", testName + ".out.html"), 'utf8', cb);

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,7 @@ function createIt(testName) {
   return function(cb) {
     var batch = new Batch();
     batch.push(function(cb) {
-      juice.juiceFile(path.join(__dirname, "html", testName + ".in.html"), {relativeTo: 'test/html/'}, cb);
+      juice.juiceFile(path.join(__dirname, "html", testName + ".in.html"), {}, cb);
     });
     batch.push(function(cb) {
       fs.readFile(path.join(__dirname, "html", testName + ".out.html"), 'utf8', cb);


### PR DESCRIPTION
@rauchg really sorry this PR is so large, but it removes all of the code that was inlining external resources and cleans up whatever was along the way. From what I can figure, juice used to use grunt-inline, which is kind of a mess, so based on that I wrote a new resource inliner that is at https://www.npmjs.com/package/web-resource-inliner and is a straight node library instead of a grunt task.

The only big breaking change here is that I removed the overloaded `juice.juice()` call so someone would now be required to use `juiceFile`, `juiceDocument` or `juiceContent` for example. These all have a callback as the last argument, which keeps things standard and is with node convention.

I simplified/standardized the test runners, as they had become a mess, the same tests are all there, but the runner is simpler.

This would presumably be a major version bump if it can be merged in based on the interface and dependency changes. It would probably be a good idea to make a minor version release based on the last set of changes before merging this in.

Thank you.