### PR TITLE
update docs, revert signature on inlineContent

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -55,7 +55,7 @@ juice.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
 juice.widthElements = ['TABLE', 'TD', 'IMG'];
 
 juice.juiceDocument = juiceDocument;
-juice.juiceContent = juiceContent;
+juice.juiceResources = juiceResources;
 juice.juiceFile = juiceFile;
 juice.inlineDocument = inlineDocument;
 juice.inlineContent = inlineContent;
@@ -172,7 +172,7 @@ function juiceDocument($, options) {
   return $;
 }
 
-function juiceContent(html, options, callback) {
+function juiceResources(html, options, callback) {
   options = getDefaultOptions(options);
 
   var onInline = function(err, html) {
@@ -193,8 +193,6 @@ function getDefaultOptions(options) {
     extraCss: "",
     applyStyleTags: true,
     removeStyleTags: true,
-    applyLinkTags: true,
-    removeLinkTags: true,
     preserveMediaQueries: false,
     applyWidthAttributes: false,
   }, options);
@@ -213,21 +211,14 @@ function juiceFile(filePath, options, callback) {
       var rel = path.dirname(path.relative(process.cwd(),filePath));
       options.webResources.relativeTo = rel;
     };
-    juiceContent(content, options, callback);
+    juiceResources(content, options, callback);
   });
 }
 
-function inlineContent(html, css, options, callback) {
-  var onInline = function(err, html){
-    if(err){
-      return callback(err);
-    }
+function inlineContent(html, css, options) {
     var $ = utils.cheerio(html);
-    inlineDocument($, css, {});
-    callback(null, $.html());
-  }
-
-  utils.inlineExternal(html, options.webResources, onInline);
+    inlineDocument($, css, options);
+    return $.html();
 }
 
 function getStylesData($, options) {

--- a/test/run.js
+++ b/test/run.js
@@ -57,10 +57,10 @@ function test (testName, options) {
     };
 
     if(config === null) {
-      juice.inlineContent(html, css, options, onJuiced);
+      onJuiced(null, juice.inlineContent(html, css, options));
     }
     else {
-      juice.juiceContent(html, config, onJuiced);
+      juice.juiceResources(html, config, onJuiced);
     }
   };
 }


### PR DESCRIPTION
- Updated docs as needed for current master, refers to cheerio instead of jsdom, updated all signatures, worked to make docs more consistently formatted
- Removed unused options
- Reverted signature on `inlineContent` based on my reading the docs, it was previously stated that it just uses the provided CSS string, so getting resources didn't make sense as it would change the stated intended behavior of the method.
- Proposing the name `juiceContent` be changed to `juiceResources` - to make it clearer it fetches remote resources and to distinguish that `juiceContent` isn't a mirror of `inlineContent` as the names were confusing to me. As long as the interface is changing, this would be the time to do this if we want to. Otherwise I can revert it.

@rauchg @parshap
