### PR TITLE
Adding support for table style attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All juice methods take an options object that can contain any of these propertie
  * `removeStyleTags` - whether to remove the original `<style></style>` tags after (possibly) inlining the css from them. Defaults to `true`.
  * `preserveMediaQueries` - preserves all media queries (and contained styles) within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. Defaults to `false`.
  * `applyWidthAttributes` - whether to use any CSS pixel widths to create `width` attributes on elements set in `juice.widthElements`. Defaults to `false`.
+ * `applyAttributesTableElements` - whether to create attributes for styles in `juice.styleToAttribute` on elements set in `juice.tableElements`. Defaults to `false`.
  * `webResources` - An options object that will be passed through to web-resource-inliner for juice functions that will get remote resources (`juiceResources` and `juiceFile`). Defaults to `{}`.
 
 ### Methods
@@ -113,6 +114,14 @@ Array of ignored pseudo-selectors such as 'hover' and 'active'.
 #### juice.widthElements
 
 Array of HTML elements that can receive `width` attributes.
+
+#### juice.styleToAttribute
+
+Object of style property names (key) to their respective attribute names (value).
+
+#### juice.tableElements
+
+Array of table HTML elements that can receive attributes defined in `juice.styleToAttribute`.
 
 ## Credits
 

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -53,6 +53,13 @@ juice.utils = require('./utils');
 
 juice.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
 juice.widthElements = ['TABLE', 'TD', 'IMG'];
+juice.tableElements = ['TABLE', 'TD', 'TH', 'TR', 'TD', 'CAPTION', 'COLGROUP', 'COL', 'THEAD', 'TBODY', 'TFOOT'];
+juice.styleToAttribute = {
+  'background-color': 'bgcolor',
+  'background-image': 'background',
+  'text-align': 'align',
+  'vertical-align': 'valign'
+};
 
 juice.juiceDocument = juiceDocument;
 juice.juiceResources = juiceResources;
@@ -70,6 +77,10 @@ function inlineDocument($, css, options) {
 
   if (options && options.applyWidthAttributes) {
     editedElements.forEach(setWidthAttrs);
+  }
+
+  if (options && options.applyAttributesTableElements) {
+    editedElements.forEach(setAttributesOnTableElements);
   }
 
   function handleRule(rule) {
@@ -162,6 +173,19 @@ function inlineDocument($, css, options) {
       }
     }
   }
+
+  function setAttributesOnTableElements(el) {
+    var elName = el.name.toUpperCase(),
+        styleProps = Object.keys(juice.styleToAttribute);
+
+    if (juice.tableElements.indexOf(elName) > -1) {
+      for (var i in el.styleProps) {
+        if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
+          $(el).attr(juice.styleToAttribute[el.styleProps[i].prop], el.styleProps[i].value);
+        }
+      }
+    }
+  }
 }
 
 function juiceDocument($, options) {
@@ -196,6 +220,7 @@ function getDefaultOptions(options) {
     removeStyleTags: true,
     preserveMediaQueries: false,
     applyWidthAttributes: false,
+    applyAttributesTableElements: false,
     url: ""
   }, options);
 

--- a/test/cases/juice-content/table-attr.html
+++ b/test/cases/juice-content/table-attr.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <style>
+        p, td, img {
+            text-align: center;
+            vertical-align: middle;
+        }
+
+        table {
+            background-image: url('test.png');
+            background-color: red;
+        }
+    </style>
+</head>
+<body>
+    <p>none</p>
+    <table>
+        <tr>
+            <td>
+                wide
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/test/cases/juice-content/table-attr.json
+++ b/test/cases/juice-content/table-attr.json
@@ -1,0 +1,5 @@
+{
+    "url": "./",
+    "removeStyleTags": true,
+    "applyAttributesTableElements": true
+}

--- a/test/cases/juice-content/table-attr.out
+++ b/test/cases/juice-content/table-attr.out
@@ -1,0 +1,15 @@
+<html>
+<head>
+    
+</head>
+<body>
+    <p style="text-align: center; vertical-align: middle;">none</p>
+    <table style="background-color: red; background-image: url('test.png');" background="url('test.png')" bgcolor="red">
+        <tr>
+            <td style="text-align: center; vertical-align: middle;" align="center" valign="middle">
+                wide
+            </td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
Adding an option to add style attributes on the table elements on top of the already inlined styles. This is required for certain email clients. This commit adds attributes for background-color, background-image, vertical-align and text-align to table elements.