### PR TITLE
Add inHead attribute to copy styles to <head>

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -355,15 +355,24 @@ function inlineContent(html, css, options) {
 function getStylesData($, options) {
   var results = [];
   var stylesList = $("style");
-  var i, styleDataList, styleData, styleElement;
+  var i, styleDataList, styleData, styleElement, inHead;
   stylesList.each(function () {
     styleElement = this;
     styleDataList = styleElement.childNodes;
     if (styleDataList.length !== 1) {
       return;
     }
+    //If "inHead" attr is set, put CSS file content in <style> tags in head section.
+    inHead = styleElement.attribs.inHead !== undefined;
     styleData = styleDataList[0].data;
-    if ( options.applyStyleTags ) results.push( styleData );
+    if (options.applyStyleTags){
+      if(inHead){
+        $("head").append("<style>"+styleData+"</style>");
+      }else{
+        results.push( styleData );
+      }
+    }
+
     if ( options.removeStyleTags )
     {
       if ( options.preserveMediaQueries )
@@ -379,6 +388,7 @@ function getStylesData($, options) {
   });
   return results;
 }
+
 
 function extractCssFromDocument($, options) {
   var results = getStylesData($, options);


### PR DESCRIPTION
You can now add an "inHead" attribute to the CSS's \<link\> tag to copy styles from that stylesheet into a \<style\> element in the document \<head\>.

The styles are NOT applied inline, and the stylesheet \<link\> is removed.

I was using Juice to inline-style an email from external CSS files. I needed one to go into \<style\> element in the document head as it contained media queries. I couldn't find existing functionality. 

This update may be of use to others.