### PR TITLE
fix undefined options

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -163,7 +163,7 @@ function inlineDocument($, css, options) {
       function addProps (style, selector) {
         for (var i = 0, l = style.length; i < l; i++) {
           var name = style[i];
-          var value = style[name] + (options.preserveImportant && style._importants[name] ? ' !important' : '');
+          var value = style[name] + (options && options.preserveImportant && style._importants[name] ? ' !important' : '');
           var sel = style._importants[name] ? importantSelector : selector;
           var prop = new Property(name, value, sel);
           var existing = el.styleProps[name];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juice",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Inlines css into html source",
   "bin": "./bin/juice",
   "main": "./lib/juice",

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /*!
  * Juice unit tests.
@@ -7,11 +8,11 @@
  * Test dependencies.
  */
 
-var juice = require('../')
-  , Selector = juice.Selector
-  , Property = juice.Property
-  , utils = juice.utils
-  , assert = require('assert');
+var juice = require('../');
+var Selector = juice.Selector;
+var Property = juice.Property;
+var utils = juice.utils;
+var assert = require('assert');
 
 /**
  * Tests.
@@ -54,7 +55,7 @@ it('selector specificity comparison', function () {
 it('selector specificity calculator', function () {
     function spec (selector) {
       return new Selector(selector).specificity();
-    };
+    }
 
     assert.deepEqual(spec('#test'),[0, 1, 0, 0]);
     assert.deepEqual(spec('#a #b #c'),[0, 3, 0, 0]);
@@ -72,18 +73,18 @@ it('property comparison based on selector specificity', function () {
       return new Property(k, v, new Selector(sel));
     }
 
-    var a = prop('color', 'white', '#woot')
-      , b = prop('color', 'red', '#a #woot')
+    var a = prop('color', 'white', '#woot');
+    var b = prop('color', 'red', '#a #woot');
 
     assert.deepEqual(a.compare(b),b);
 
-    var a = prop('background-color', 'red', '#a')
-      , b = prop('background-color', 'red', '.a.b.c')
+    a = prop('background-color', 'red', '#a');
+    b = prop('background-color', 'red', '.a.b.c');
 
     assert.deepEqual(a.compare(b),a);
 
-    var a = prop('background-color', 'red', '#a .b.c')
-      , b = prop('background-color', 'red', '.a.b.c #c')
+    a = prop('background-color', 'red', '#a .b.c');
+    b = prop('background-color', 'red', '.a.b.c #c');
 
     assert.deepEqual(a.compare(b),b);
 } );

--- a/test/run.js
+++ b/test/run.js
@@ -1,9 +1,10 @@
+"use strict";
 
-var juice = require('../')
-  , utils = require('../lib/utils')
-  , basename = require('path').basename
-  , fs = require('fs')
-  , assert = require('assert');
+var juice = require('../');
+var utils = require('../lib/utils');
+var basename = require('path').basename;
+var fs = require('fs');
+var assert = require('assert');
 
 
 /**
@@ -38,10 +39,10 @@ function read (file) {
 }
 
 function test (testName, options) {
-  var base = __dirname + '/cases/' + testName
-    , html =  read(base + '.html')
-    , css = read( base + '.css' )
-    , config = options ? JSON.parse( read( base + '.json' ) ) : null;
+  var base = __dirname + '/cases/' + testName;
+  var html =  read(base + '.html');
+  var css = read( base + '.css' );
+  var config = options ? JSON.parse( read( base + '.json' ) ) : null;
 
   options = {};
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,13 @@
 /*globals describe:false it:false*/
-var juice = require('../')
-  , utils = require('../lib/utils')
-  , path = require('path')
-  , fs = require('fs')
-  , Batch = require('batch')
-  , assert = require('assert');
+
+"use strict";
+
+var juice = require('../');
+var utils = require('../lib/utils');
+var path = require('path');
+var fs = require('fs');
+var Batch = require('batch');
+var assert = require('assert');
 
 var tests = [
   "doctype",
@@ -16,6 +19,14 @@ var tests = [
 
 tests.forEach(function(testName) {
   it(testName, createIt(testName));
+});
+
+it("inlineContent", function()
+{
+  var html = '<p>Hello</p>';
+  var css = 'p{font-weight:bold;}';
+
+  assert.strictEqual(juice.inlineContent(html, css), '<p style="font-weight: bold;">Hello</p>');
 });
 
 function createIt(testName) {


### PR DESCRIPTION
fixes #137 

Fixes the error and adds a test case that uses `inlineContent` now which should prevent regression.

Also, some more linting in here, tests were not updated to be `use_strict` compliant on the last CL.