### PR TITLE
Update web-resource-inliner to the latest version, add license to package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha --reporter spec",
     "testcover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
   },
+  "license": "MIT",
   "contributors": [
     {
       "name": "Guillermo Rauch",
@@ -39,7 +40,7 @@
     "commander": "2.3.0",
     "cssom": "0.3.0",
     "slick": "1.12.1",
-    "web-resource-inliner": "1.1.2"
+    "web-resource-inliner": "1.1.3"
   },
   "devDependencies": {
     "should": "4.0.4",


### PR DESCRIPTION
This PR adds the license to the package file and updates `web-resource-inliner` so it uses the latest version which doesn't use the vulnerable version of `uglify-js`. The new version of `web-resource-inliner` has a PR already created jrit/web-resource-inliner#8 and this is being done in response to this advisory: https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons