### PR TITLE
Enabled percentages for tableElements on 'applyWidthAttributes' option.

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -220,10 +220,16 @@ function inlineDocument($, css, options) {
     var elName = el.name.toUpperCase();
     if (juice.widthElements.indexOf(elName) > -1) {
       for (var i in el.styleProps) {
-        if (el.styleProps[i].prop === 'width' && el.styleProps[i].value.match(/px/)) {
-          var pxWidth = el.styleProps[i].value.replace('px', '');
-          $(el).attr('width', pxWidth);
-          return;
+        if (el.styleProps[i].prop === 'width') {
+          if (el.styleProps[i].value.match(/px/)) {
+            var pxWidth = el.styleProps[i].value.replace('px', '');
+            $(el).attr('width', pxWidth);
+            return;
+          }
+          if (juice.tableElements.indexOf(elName) > -1 && el.styleProps[i].value.match(/\%/)) {
+            $(el).attr('width', el.styleProps[i].value);
+            return;
+          }
         }
       }
     }

--- a/test/cases/juice-content/width-attr.html
+++ b/test/cases/juice-content/width-attr.html
@@ -1,8 +1,11 @@
 <html>
 <head>
     <style>
-        p, td, img {
+        p, td.px, img.px {
             width: 200px;
+        }
+        td.percentage, img.percentage {
+            width: 50%;
         }
     </style>
 </head>
@@ -10,11 +13,15 @@
     <p>none</p>
     <table>
         <tr>
-            <td>
+            <td class="px">
+                wide
+            </td>
+            <td class="percentage">
                 wide
             </td>
         </tr>
     </table>
-    <img src="" alt="wide">
+    <img src="" alt="wide" class="px">
+    <img src="" alt="wide" class="percentage">
 </body>
 </html>

--- a/test/cases/juice-content/width-attr.out
+++ b/test/cases/juice-content/width-attr.out
@@ -6,11 +6,15 @@
     <p style="width: 200px;">none</p>
     <table>
         <tr>
-            <td style="width: 200px;" width="200">
+            <td class="px" style="width: 200px;" width="200">
+                wide
+            </td>
+            <td class="percentage" style="width: 50%;" width="50%">
                 wide
             </td>
         </tr>
     </table>
-    <img src="" alt="wide" style="width: 200px;" width="200">
+    <img src="" alt="wide" class="px" style="width: 200px;" width="200">
+    <img src="" alt="wide" class="percentage" style="width: 50%;">
 </body>
 </html>


### PR DESCRIPTION
Mapping percentages width attributes in table elements is useful for fluid layouts and does not break any specs.