### PR TITLE
Fix bug with reference to pseudo element object

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -138,7 +138,7 @@ function inlineDocument($, css, options) {
         var pseudoElPropName = "pseudo" + pseudoElementType;
         var pseudoEl = el[pseudoElPropName];
         if (!pseudoEl) {
-          pseudoEl = el[pseudoElPropName] = $("<span />");
+          pseudoEl = el[pseudoElPropName] = $("<span />").get(0);
           pseudoEl.pseudoElementType = pseudoElementType;
           pseudoEl.pseudoElementParent = el;
           el[pseudoElPropName] = pseudoEl;
@@ -205,7 +205,7 @@ function inlineDocument($, css, options) {
 
   function inlinePseudoElements(el) {
     if (el.pseudoElementType && el.styleProps.content) {
-      el.html(parseContent(el.styleProps.content.value));
+      $(el).html(parseContent(el.styleProps.content.value));
       var parent = el.pseudoElementParent;
       if (el.pseudoElementType === "before") {
         $(parent).prepend(el);

--- a/test/cases/juice-content/pseudo-elements-and-width-attr.html
+++ b/test/cases/juice-content/pseudo-elements-and-width-attr.html
@@ -1,0 +1,41 @@
+<html><body>
+<style>
+a {
+  text-decoration: underline;
+}
+
+a:before,
+a:after {
+  content: "a";
+}
+
+* a:before {
+  content: '®\+';
+}
+
+a:after,
+a::after {
+  font-weight: bold;
+}
+
+a:first-child {
+  color: blue;
+}
+
+b:after {
+ content: " ";
+}
+
+b:after {
+ content: "b";
+ color: green;
+}
+
+b :last-child {
+  color: red;
+}
+</style>
+<a href="#">Test</a>
+<b></b>
+<b><span></span></b>
+</body></html>

--- a/test/cases/juice-content/pseudo-elements-and-width-attr.json
+++ b/test/cases/juice-content/pseudo-elements-and-width-attr.json
@@ -1,0 +1,6 @@
+{
+  "url": "./",
+  "removeStyleTags": true,
+  "inlinePseudoElements": true,
+  "applyWidthAttributes": true
+}

--- a/test/cases/juice-content/pseudo-elements-and-width-attr.out
+++ b/test/cases/juice-content/pseudo-elements-and-width-attr.out
@@ -1,0 +1,6 @@
+<html><body>
+
+<a href="#" style="text-decoration: underline; color: blue;"><span>®+</span>Test<span style="font-weight: bold;">a</span></a>
+<b><span style="color: green;">b</span></b>
+<b><span style="color: red;"></span><span style="color: green;">b</span></b>
+</body></html>


### PR DESCRIPTION
The element object is currently referencing a jQuery object that wraps the created pseudo element, but the rest of the code expects to be working with raw dom element objects.

This change fixes it by calling `.get(0)` on the created jQuery object so it becomes a normal dom element object.