### PR TITLE
Implement a `data-embed` attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Array of table HTML elements that can receive attributes defined in `juice.style
 
 Array of elements that will not have styles inlined because they are not intended to render.
 
+### Special markup
+
+#### data-embed
+When a `data-embed` attribute is present on a stylesheet `<link>` that has been inlined into the document as a `<style></style>` tag by the web-resource-inliner juice will not inline the styles and will not remove the `<style></style>` tags.
+
+This can be used to embed email client support hacks that rely on css selectors into your email templates.
 
 ### CLI Options
 

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -381,10 +381,10 @@ function getStylesData($, options) {
       return;
     }
     styleData = styleDataList[0].data;
-    if ( options.applyStyleTags ) {
+    if ( options.applyStyleTags && styleElement.attribs['data-embed'] === undefined  ) {
       results.push( styleData );
     }
-    if ( options.removeStyleTags )
+    if ( options.removeStyleTags && styleElement.attribs['data-embed'] === undefined  )
     {
       var preservedText = utils.getPreservedText( styleElement.childNodes[0].nodeValue, {
           mediaQueries: options.preserveMediaQueries,
@@ -399,6 +399,7 @@ function getStylesData($, options) {
         $(styleElement).remove();
       }
     }
+    delete styleElement.attribs['data-embed'];
   });
   return results;
 }

--- a/test/cases/juice-content/embed.css
+++ b/test/cases/juice-content/embed.css
@@ -1,0 +1,3 @@
+p {
+    color: blue;
+}

--- a/test/cases/juice-content/embed.html
+++ b/test/cases/juice-content/embed.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="embed.css" data-embed />
+</head>
+<body>
+    <p>hi</p>
+</body>
+</html>

--- a/test/cases/juice-content/embed.json
+++ b/test/cases/juice-content/embed.json
@@ -1,0 +1,4 @@
+{
+    "url": "./test/cases/juice-content",
+    "removeStyleTags": true
+}

--- a/test/cases/juice-content/embed.out
+++ b/test/cases/juice-content/embed.out
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <style type="text/css">
+p {
+    color: blue;
+}
+</style>
+</head>
+<body>
+    <p>hi</p>
+</body>
+</html>


### PR DESCRIPTION
This attribute is intended for use on `<link>` tags.

When the <link> is inlined the styles in the <style> will not be inlined and the tag will not be removed.

This fixes #164 and replaces #129