### PR TITLE
Refactor to provide browser support at juice/client

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.6.1 / 2015-10-31
+==================
+
+* Refactor to provide browser support at `juice/client`
+
 1.6.0 / 2015-10-26
 ==================
 

--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-1.6.1 / 2015-10-31
+1.6.1 / Pending
 ==================
 
 * Refactor to provide browser support at `juice/client`

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Current CLI options:
 
 - `--css [filepath]` will load and inject CSS into `extraCss`.
 
+### Running Juice in the Browser
+
+Attempting to Browserify `require('juice')` fails because portions of Juice and its dependencies interact with the file system using the standard `require('fs')`. However, you can `require('juice/client')` via Browserify which has support for `juiceDocument`, `inlineDocument`, and `inlineContent`, but not `juiceFile`, `juiceResources`, or `inlineExternal`. *Note that automated tests are not running in the browser yet.*
 
 ## Credits
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,311 @@
+ "use strict";
+
+var utils = require('./utils');
+
+var juiceClient = function (html,options) {
+  var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});
+  var doc = juiceDocument($,options);
+
+  if (options && options.xmlMode){
+    return doc.xml();
+  }
+  else {
+    return utils.decodeEntities(doc.html());
+  }
+};
+
+module.exports = juiceClient;
+
+juiceClient.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
+juiceClient.widthElements = ['TABLE', 'TD', 'IMG'];
+juiceClient.tableElements = ['TABLE', 'TD', 'TH', 'TR', 'TD', 'CAPTION', 'COLGROUP', 'COL', 'THEAD', 'TBODY', 'TFOOT'];
+juiceClient.nonVisualElements = [ "HEAD", "TITLE", "BASE", "LINK", "STYLE", "META", "SCRIPT", "NOSCRIPT" ];
+juiceClient.styleToAttribute = {
+  'background-color': 'bgcolor',
+  'background-image': 'background',
+  'text-align': 'align',
+  'vertical-align': 'valign'
+};
+
+juiceClient.juiceDocument = juiceDocument;
+juiceClient.inlineDocument = inlineDocument;
+juiceClient.inlineContent = inlineContent;
+
+function inlineDocument($, css, options) {
+
+  var rules = utils.parseCSS(css);
+  var editedElements = [];
+
+  rules.forEach(handleRule);
+  editedElements.forEach(setStyleAttrs);
+
+  if (options && options.inlinePseudoElements) {
+    editedElements.forEach(inlinePseudoElements);
+  }
+
+  if (options && options.applyWidthAttributes) {
+    editedElements.forEach(setWidthAttrs);
+  }
+
+  if (options && options.applyAttributesTableElements) {
+    editedElements.forEach(setAttributesOnTableElements);
+  }
+
+  function handleRule(rule) {
+    var sel = rule[0];
+    var style = rule[1];
+    var selector = new utils.Selector(sel);
+    var parsedSelector = selector.parsed();
+    var pseudoElementType = getPseudoElementType(parsedSelector);
+
+    // skip rule if the selector has any pseudos which are ignored
+    for (var i = 0; i < parsedSelector.length; ++i) {
+      var subSel = parsedSelector[i];
+      if (subSel.pseudos) {
+        for (var j = 0; j < subSel.pseudos.length; ++j) {
+          var subSelPseudo = subSel.pseudos[j];
+          if (juiceClient.ignoredPseudos.indexOf(subSelPseudo.name) >= 0) {
+            return;
+          }
+        }
+      }
+    }
+
+    if (pseudoElementType) {
+      var last = parsedSelector[parsedSelector.length - 1];
+      var pseudos = last.pseudos;
+      last.pseudos = filterElementPseudos(last.pseudos);
+      sel = parsedSelector.toString();
+      last.pseudos = pseudos;
+    }
+
+    var els;
+    try {
+      els = $(sel);
+    } catch (err) {
+      // skip invalid selector
+      return;
+    }
+
+    els.each(function () {
+      var el = this;
+
+      if (el.name && juiceClient.nonVisualElements.indexOf(el.name.toUpperCase()) >= 0) {
+          return;
+      }
+
+      if (pseudoElementType) {
+        var pseudoElPropName = "pseudo" + pseudoElementType;
+        var pseudoEl = el[pseudoElPropName];
+        if (!pseudoEl) {
+          pseudoEl = el[pseudoElPropName] = $("<span />").get(0);
+          pseudoEl.pseudoElementType = pseudoElementType;
+          pseudoEl.pseudoElementParent = el;
+          el[pseudoElPropName] = pseudoEl;
+        }
+        el = pseudoEl;
+      }
+
+      if (!el.styleProps) {
+        el.styleProps = {};
+
+        // if the element has inline styles, fake selector with topmost specificity
+        if ($(el).attr('style')) {
+          var cssText = '* { ' + $(el).attr('style') + ' } ';
+          addProps(utils.parseCSS(cssText)[0][1], utils.styleSelector);
+        }
+
+        // store reference to an element we need to compile style="" attr for
+        editedElements.push(el);
+      }
+
+      // go through the properties
+      function addProps (style, selector) {
+        for (var i = 0, l = style.length; i < l; i++) {
+          var name = style[i];
+          var value = style[name] + (options && options.preserveImportant && style._importants[name] ? ' !important' : '');
+          var sel = style._importants[name] ? utils.importantSelector : selector;
+          var prop = new utils.Property(name, value, sel);
+          var existing = el.styleProps[name];
+
+          if (existing && existing.compare(prop) === prop || !existing) {
+            el.styleProps[name] = prop;
+          }
+        }
+      }
+
+      addProps(style, selector);
+    });
+  }
+
+  function setStyleAttrs(el) {
+    var props = Object.keys(el.styleProps).map(function(key) {
+      return el.styleProps[key];
+    });
+    // sort properties by their originating selector's specificity so that
+    // props like "padding" and "padding-bottom" are resolved as expected.
+    props.sort(function(a, b) {
+      return a.selector.specificity().join("").localeCompare(
+        b.selector.specificity().join(""));
+    });
+    var string = props
+      .filter(function(prop) {
+        // Content becomes the innerHTML of pseudo elements, not used as a
+        // style property
+        return prop.prop !== "content";
+      })
+      .map(function(prop) {
+        return prop.prop + ": " + prop.value.replace(/["]/g, "'") + ";";
+      })
+      .join(" ");
+    if (string) {
+      $(el).attr('style', string);
+    }
+  }
+
+  function inlinePseudoElements(el) {
+    if (el.pseudoElementType && el.styleProps.content) {
+      $(el).html(parseContent(el.styleProps.content.value));
+      var parent = el.pseudoElementParent;
+      if (el.pseudoElementType === "before") {
+        $(parent).prepend(el);
+      }
+      else {
+        $(parent).append(el);
+      }
+    }
+  }
+
+  function setWidthAttrs(el) {
+    var elName = el.name.toUpperCase();
+    if (juiceClient.widthElements.indexOf(elName) > -1) {
+      for (var i in el.styleProps) {
+        if (el.styleProps[i].prop === 'width') {
+          if (el.styleProps[i].value.match(/px/)) {
+            var pxWidth = el.styleProps[i].value.replace('px', '');
+            $(el).attr('width', pxWidth);
+            return;
+          }
+          if (juiceClient.tableElements.indexOf(elName) > -1 && el.styleProps[i].value.match(/\%/)) {
+            $(el).attr('width', el.styleProps[i].value);
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  function setAttributesOnTableElements(el) {
+    var elName = el.name.toUpperCase(),
+        styleProps = Object.keys(juiceClient.styleToAttribute);
+
+    if (juiceClient.tableElements.indexOf(elName) > -1) {
+      for (var i in el.styleProps) {
+        if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
+          $(el).attr(juiceClient.styleToAttribute[el.styleProps[i].prop], el.styleProps[i].value);
+        }
+      }
+    }
+  }
+}
+
+function parseContent(content) {
+  if (content === "none" || content === "normal") {
+    return "";
+  }
+
+  // Naive parsing, assume well-formed value
+  content = content.slice(1, content.length - 1);
+  // Naive unescape, assume no unicode char codes
+  content = content.replace(/\\/g, "");
+  return content;
+}
+
+// Return "before" or "after" if the given selector is a pseudo element (e.g.,
+// a::after).
+function getPseudoElementType(selector) {
+  if (selector.length === 0) {
+    return;
+  }
+
+  var pseudos = selector[selector.length - 1].pseudos;
+  if (!pseudos) {
+    return;
+  }
+
+  for (var i = 0; i < pseudos.length; i++) {
+    if (isPseudoElementName(pseudos[i])) {
+      return pseudos[i].name;
+    }
+  }
+}
+
+function isPseudoElementName(pseudo) {
+  return pseudo.name === "before" || pseudo.name === "after";
+}
+
+function filterElementPseudos(pseudos) {
+  return pseudos.filter(function(pseudo) {
+    return !isPseudoElementName(pseudo);
+  });
+}
+
+function juiceDocument($, options) {
+  options = utils.getDefaultOptions(options);
+  var css = extractCssFromDocument($, options);
+  css += "\n" + options.extraCss;
+  inlineDocument($, css, options);
+  return $;
+}
+
+function inlineContent(html, css, options) {
+    var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});
+    inlineDocument($, css, options);
+
+    if (options && options.xmlMode){
+      return $.xml();
+    }
+    else {
+      return utils.decodeEntities($.html());
+    }
+}
+
+function getStylesData($, options) {
+  var results = [];
+  var stylesList = $("style");
+  var styleDataList, styleData, styleElement;
+  stylesList.each(function () {
+    styleElement = this;
+    styleDataList = styleElement.childNodes;
+    if (styleDataList.length !== 1) {
+      return;
+    }
+    styleData = styleDataList[0].data;
+    if ( options.applyStyleTags && styleElement.attribs['data-embed'] === undefined  ) {
+      results.push( styleData );
+    }
+    if ( options.removeStyleTags && styleElement.attribs['data-embed'] === undefined  )
+    {
+      var preservedText = utils.getPreservedText( styleElement.childNodes[0].nodeValue, {
+          mediaQueries: options.preserveMediaQueries,
+          fontFaces: options.preserveFontFaces
+      } );
+      if ( preservedText )
+      {
+        styleElement.childNodes[0].nodeValue = preservedText;
+      }
+      else
+      {
+        $(styleElement).remove();
+      }
+    }
+    delete styleElement.attribs['data-embed'];
+  });
+  return results;
+}
+
+function extractCssFromDocument($, options) {
+  var results = getStylesData($, options);
+  var css = results.join("\n");
+  return css;
+}

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -12,299 +12,57 @@
  */
 
 var utils = require('./utils');
-var Selector = require('./selector');
-var Property = require('./property');
 var packageJson = require('../package');
 var fs = require('fs');
 var path = require('path');
-var styleSelector = new Selector('<style attribute>', [1, 0, 0, 0]);
-var importantSelector = new Selector('<!important>', [2, 0, 0, 0]);
-
-var juice = function (html,options) {
-  var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});
-  var doc = juiceDocument($,options);
-
-  if (options && options.xmlMode){
-    return doc.xml();
-  }
-  else {
-    return utils.decodeEntities(doc.html());
-  }
-};
+var inline = require('web-resource-inliner');
+var juiceClient = require('./client');
+var juice = juiceClient;
 
 module.exports = juice;
 
-/**
- * Package version
- */
-
 juice.version = packageJson.version;
 
-/**
- * Export Selector.
- */
+juice.Selector = utils.Selector;
+juice.Property = utils.Property;
+juice.utils = utils;
 
-juice.Selector = Selector;
+juice.ignoredPseudos = juiceClient.ignoredPseudos;
+juice.widthElements = juiceClient.widthElements;
+juice.tableElements = juiceClient.tableElements;
+juice.nonVisualElements = juiceClient.nonVisualElements;
+juice.styleToAttribute = juiceClient.styleToAttribute;
 
-/**
- * Export Property.
- */
+juice.juiceDocument = juiceClient.juiceDocument;
+juice.inlineDocument = juiceClient.inlineDocument;
+juice.inlineContent = juiceClient.inlineContent;
 
-juice.Property = Property;
-
-/**
- * Export utils.
- */
-
-juice.utils = require('./utils');
-
-
-juice.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
-juice.widthElements = ['TABLE', 'TD', 'IMG'];
-juice.tableElements = ['TABLE', 'TD', 'TH', 'TR', 'TD', 'CAPTION', 'COLGROUP', 'COL', 'THEAD', 'TBODY', 'TFOOT'];
-juice.nonVisualElements = [ "HEAD", "TITLE", "BASE", "LINK", "STYLE", "META", "SCRIPT", "NOSCRIPT" ];
-juice.styleToAttribute = {
-  'background-color': 'bgcolor',
-  'background-image': 'background',
-  'text-align': 'align',
-  'vertical-align': 'valign'
-};
-
-juice.juiceDocument = juiceDocument;
-juice.juiceResources = juiceResources;
 juice.juiceFile = juiceFile;
-juice.inlineDocument = inlineDocument;
-juice.inlineContent = inlineContent;
+juice.juiceResources = juiceResources;
+juice.inlineExternal = inlineExternal;
 
-function inlineDocument($, css, options) {
-
-  var rules = utils.parseCSS(css);
-  var editedElements = [];
-
-  rules.forEach(handleRule);
-  editedElements.forEach(setStyleAttrs);
-
-  if (options && options.inlinePseudoElements) {
-    editedElements.forEach(inlinePseudoElements);
-  }
-
-  if (options && options.applyWidthAttributes) {
-    editedElements.forEach(setWidthAttrs);
-  }
-
-  if (options && options.applyAttributesTableElements) {
-    editedElements.forEach(setAttributesOnTableElements);
-  }
-
-  function handleRule(rule) {
-    var sel = rule[0];
-    var style = rule[1];
-    var selector = new Selector(sel);
-    var parsedSelector = selector.parsed();
-    var pseudoElementType = getPseudoElementType(parsedSelector);
-
-    // skip rule if the selector has any pseudos which are ignored
-    for (var i = 0; i < parsedSelector.length; ++i) {
-      var subSel = parsedSelector[i];
-      if (subSel.pseudos) {
-        for (var j = 0; j < subSel.pseudos.length; ++j) {
-          var subSelPseudo = subSel.pseudos[j];
-          if (juice.ignoredPseudos.indexOf(subSelPseudo.name) >= 0) {
-            return;
-          }
-        }
-      }
+function juiceFile(filePath, options, callback) {
+  // set default options
+  fs.readFile(filePath, 'utf8', function(err, content) {
+    if (err) {
+      return callback(err);
     }
-
-    if (pseudoElementType) {
-      var last = parsedSelector[parsedSelector.length - 1];
-      var pseudos = last.pseudos;
-      last.pseudos = filterElementPseudos(last.pseudos);
-      sel = parsedSelector.toString();
-      last.pseudos = pseudos;
+    options = utils.getDefaultOptions(options); // so we can mutate options without guilt
+    if(!options.webResources.relativeTo){
+      var rel = path.dirname(path.relative(process.cwd(),filePath));
+      options.webResources.relativeTo = rel;
     }
-
-    var els;
-    try {
-      els = $(sel);
-    } catch (err) {
-      // skip invalid selector
-      return;
-    }
-
-    els.each(function () {
-      var el = this;
-
-      if (el.name && juice.nonVisualElements.indexOf(el.name.toUpperCase()) >= 0) {
-          return;
-      }
-
-      if (pseudoElementType) {
-        var pseudoElPropName = "pseudo" + pseudoElementType;
-        var pseudoEl = el[pseudoElPropName];
-        if (!pseudoEl) {
-          pseudoEl = el[pseudoElPropName] = $("<span />").get(0);
-          pseudoEl.pseudoElementType = pseudoElementType;
-          pseudoEl.pseudoElementParent = el;
-          el[pseudoElPropName] = pseudoEl;
-        }
-        el = pseudoEl;
-      }
-
-      if (!el.styleProps) {
-        el.styleProps = {};
-
-        // if the element has inline styles, fake selector with topmost specificity
-        if ($(el).attr('style')) {
-          var cssText = '* { ' + $(el).attr('style') + ' } ';
-          addProps(utils.parseCSS(cssText)[0][1], styleSelector);
-        }
-
-        // store reference to an element we need to compile style="" attr for
-        editedElements.push(el);
-      }
-
-      // go through the properties
-      function addProps (style, selector) {
-        for (var i = 0, l = style.length; i < l; i++) {
-          var name = style[i];
-          var value = style[name] + (options && options.preserveImportant && style._importants[name] ? ' !important' : '');
-          var sel = style._importants[name] ? importantSelector : selector;
-          var prop = new Property(name, value, sel);
-          var existing = el.styleProps[name];
-
-          if (existing && existing.compare(prop) === prop || !existing) {
-            el.styleProps[name] = prop;
-          }
-        }
-      }
-
-      addProps(style, selector);
-    });
-  }
-
-  function setStyleAttrs(el) {
-    var props = Object.keys(el.styleProps).map(function(key) {
-      return el.styleProps[key];
-    });
-    // sort properties by their originating selector's specificity so that
-    // props like "padding" and "padding-bottom" are resolved as expected.
-    props.sort(function(a, b) {
-      return a.selector.specificity().join("").localeCompare(
-        b.selector.specificity().join(""));
-    });
-    var string = props
-      .filter(function(prop) {
-        // Content becomes the innerHTML of pseudo elements, not used as a
-        // style property
-        return prop.prop !== "content";
-      })
-      .map(function(prop) {
-        return prop.prop + ": " + prop.value.replace(/["]/g, "'") + ";";
-      })
-      .join(" ");
-    if (string) {
-      $(el).attr('style', string);
-    }
-  }
-
-  function inlinePseudoElements(el) {
-    if (el.pseudoElementType && el.styleProps.content) {
-      $(el).html(parseContent(el.styleProps.content.value));
-      var parent = el.pseudoElementParent;
-      if (el.pseudoElementType === "before") {
-        $(parent).prepend(el);
-      }
-      else {
-        $(parent).append(el);
-      }
-    }
-  }
-
-  function setWidthAttrs(el) {
-    var elName = el.name.toUpperCase();
-    if (juice.widthElements.indexOf(elName) > -1) {
-      for (var i in el.styleProps) {
-        if (el.styleProps[i].prop === 'width') {
-          if (el.styleProps[i].value.match(/px/)) {
-            var pxWidth = el.styleProps[i].value.replace('px', '');
-            $(el).attr('width', pxWidth);
-            return;
-          }
-          if (juice.tableElements.indexOf(elName) > -1 && el.styleProps[i].value.match(/\%/)) {
-            $(el).attr('width', el.styleProps[i].value);
-            return;
-          }
-        }
-      }
-    }
-  }
-
-  function setAttributesOnTableElements(el) {
-    var elName = el.name.toUpperCase(),
-        styleProps = Object.keys(juice.styleToAttribute);
-
-    if (juice.tableElements.indexOf(elName) > -1) {
-      for (var i in el.styleProps) {
-        if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
-          $(el).attr(juice.styleToAttribute[el.styleProps[i].prop], el.styleProps[i].value);
-        }
-      }
-    }
-  }
-}
-
-function parseContent(content) {
-  if (content === "none" || content === "normal") {
-    return "";
-  }
-
-  // Naive parsing, assume well-formed value
-  content = content.slice(1, content.length - 1);
-  // Naive unescape, assume no unicode char codes
-  content = content.replace(/\\/g, "");
-  return content;
-}
-
-// Return "before" or "after" if the given selector is a pseudo element (e.g.,
-// a::after).
-function getPseudoElementType(selector) {
-  if (selector.length === 0) {
-    return;
-  }
-
-  var pseudos = selector[selector.length - 1].pseudos;
-  if (!pseudos) {
-    return;
-  }
-
-  for (var i = 0; i < pseudos.length; i++) {
-    if (isPseudoElementName(pseudos[i])) {
-      return pseudos[i].name;
-    }
-  }
-}
-
-function isPseudoElementName(pseudo) {
-  return pseudo.name === "before" || pseudo.name === "after";
-}
-
-function filterElementPseudos(pseudos) {
-  return pseudos.filter(function(pseudo) {
-    return !isPseudoElementName(pseudo);
+    juiceResources(content, options, callback);
   });
 }
 
-function juiceDocument($, options) {
-  options = getDefaultOptions(options);
-  var css = extractCssFromDocument($, options);
-  css += "\n" + options.extraCss;
-  inlineDocument($, css, options);
-  return $;
-}
+function inlineExternal(html, inlineOptions, callback){
+  var options = utils.extend({fileContent: html}, inlineOptions);
+  inline.html(options, callback);
+};
 
 function juiceResources(html, options, callback) {
-  options = getDefaultOptions(options);
+  options = utils.getDefaultOptions(options);
 
   var onInline = function(err, html) {
     if(err){
@@ -312,7 +70,7 @@ function juiceResources(html, options, callback) {
     }
 
     var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});
-    juiceDocument($, options);
+    juiceClient.juiceDocument($, options);
 
     if (options.xmlMode){
       return callback(null, $.xml());
@@ -323,89 +81,5 @@ function juiceResources(html, options, callback) {
   };
 
   options.webResources.relativeTo = options.webResources.relativeTo || options.url; //legacy support
-  utils.inlineExternal(html, options.webResources, onInline);
-}
-
-function getDefaultOptions(options) {
-  var result = utils.extend({
-    extraCss: "",
-    applyStyleTags: true,
-    removeStyleTags: true,
-    preserveMediaQueries: false,
-    preserveFontFaces: false,
-    applyWidthAttributes: false,
-    applyAttributesTableElements: false,
-    url: ""
-  }, options);
-
-  result.webResources = result.webResources || {};
-
-  return result;
-}
-
-function juiceFile(filePath, options, callback) {
-  // set default options
-  fs.readFile(filePath, 'utf8', function(err, content) {
-    if (err) {
-      return callback(err);
-    }
-    options = getDefaultOptions(options); // so we can mutate options without guilt
-    if(!options.webResources.relativeTo){
-      var rel = path.dirname(path.relative(process.cwd(),filePath));
-      options.webResources.relativeTo = rel;
-    }
-    juiceResources(content, options, callback);
-  });
-}
-
-function inlineContent(html, css, options) {
-    var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});
-    inlineDocument($, css, options);
-
-    if (options && options.xmlMode){
-      return $.xml();
-    }
-    else {
-      return utils.decodeEntities($.html());
-    }
-}
-
-function getStylesData($, options) {
-  var results = [];
-  var stylesList = $("style");
-  var styleDataList, styleData, styleElement;
-  stylesList.each(function () {
-    styleElement = this;
-    styleDataList = styleElement.childNodes;
-    if (styleDataList.length !== 1) {
-      return;
-    }
-    styleData = styleDataList[0].data;
-    if ( options.applyStyleTags && styleElement.attribs['data-embed'] === undefined  ) {
-      results.push( styleData );
-    }
-    if ( options.removeStyleTags && styleElement.attribs['data-embed'] === undefined  )
-    {
-      var preservedText = utils.getPreservedText( styleElement.childNodes[0].nodeValue, {
-          mediaQueries: options.preserveMediaQueries,
-          fontFaces: options.preserveFontFaces
-      } );
-      if ( preservedText )
-      {
-        styleElement.childNodes[0].nodeValue = preservedText;
-      }
-      else
-      {
-        $(styleElement).remove();
-      }
-    }
-    delete styleElement.attribs['data-embed'];
-  });
-  return results;
-}
-
-function extractCssFromDocument($, options) {
-  var results = getStylesData($, options);
-  var css = results.join("\n");
-  return css;
+  inlineExternal(html, options.webResources, onInline);
 }

--- a/lib/property.js
+++ b/lib/property.js
@@ -13,7 +13,7 @@ module.exports = exports = Property;
  * Module dependencies.
  */
 
-var compare = require('./utils').compare;
+var utils = require('./utils');
 
 /**
  * CSS property constructor.
@@ -39,7 +39,7 @@ function Property (prop, value, selector) {
 Property.prototype.compare = function (property) {
   var a = this.selector.specificity();
   var b = property.selector.specificity();
-  var winner = compare(a, b);
+  var winner = utils.compare(a, b);
 
   if (winner === a && a !== b) {
     return this;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,13 @@ var cssom = require('cssom');
 var cheerio = require('cheerio');
 var own = {}.hasOwnProperty;
 var os = require('os');
-var inline = require('web-resource-inliner');
+var Selector = require('./selector');
+var Property = require('./property');
+
+exports.Selector = Selector;
+exports.Property = Property;
+exports.styleSelector = new Selector('<style attribute>', [1, 0, 0, 0]);
+exports.importantSelector = new Selector('<!important>', [2, 0, 0, 0]);
 
 /**
  * Returns an array of the selectors.
@@ -110,7 +116,6 @@ exports.getPreservedText = function ( css, options )
 		  FONT_FACE: 5,
 		*/
 
-
         if ( options.fontFaces && rules[i].type === cssom.CSSFontFaceRule.prototype.type )
  		{
             var fontFace = [ "" ];
@@ -160,11 +165,6 @@ exports.cheerio = function (html, options) {
   options = exports.extend({decodeEntities: false}, options || {});
   html = exports.encodeEntities(html);
   return cheerio.load(html,options);
-};
-
-exports.inlineExternal = function (html, inlineOptions, callback){
-  var options = exports.extend({fileContent: html}, inlineOptions);
-  inline.html(options, callback);
 };
 
 exports.normalizeLineEndings = function (text){
@@ -234,3 +234,20 @@ exports.extend = function (obj, src) {
   }
   return obj;
 };
+
+exports.getDefaultOptions = function (options) {
+  var result = exports.extend({
+    extraCss: "",
+    applyStyleTags: true,
+    removeStyleTags: true,
+    preserveMediaQueries: false,
+    preserveFontFaces: false,
+    applyWidthAttributes: false,
+    applyAttributesTableElements: false,
+    url: ""
+  }, options);
+
+  result.webResources = result.webResources || {};
+
+  return result;
+}


### PR DESCRIPTION
Sort of fixes #38 

Thanks @barretts for your research on this. This diff is huge because it keeps the existing API with no test changes, but makes `juice/client` able to be browserified with the compatible subset of features. It is just a giant refactoring.