### PR TITLE
Fix require("juice/client")

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
  "use strict";
 
-var utils = require('./utils');
+var utils = require('./lib/utils');
 
 var juiceClient = function (html,options) {
   var $ = utils.cheerio(html, { xmlMode: options && options.xmlMode});

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@
  * Module dependencies.
  */
 
-var utils = require('./utils');
-var packageJson = require('../package');
+var utils = require('./lib/utils');
+var packageJson = require('./package');
 var fs = require('fs');
 var path = require('path');
 var inline = require('web-resource-inliner');

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "juice",
   "version": "1.7.0",
   "description": "Inlines css into html source",
-  "bin": "./bin/juice",
-  "main": "./lib/juice",
+  "bin": "bin/juice",
+  "main": "index.js",
+  "browser": "client.js",
   "scripts": {
     "test": "mocha --reporter spec",
     "testcover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"


### PR DESCRIPTION
The readme documents using `require("juice/client")` for client-side (browser) use, but this file doesn't exist and the `require()` results in an error.

The following changes were made:

1. Move client entry-point from `lib/client.js` to `client.js`.

2. Move server entry-point from `lib/juice.js` to `index.js`, all entry-points are in the package's root.

3. Add "browser" field to `package.json` so that `require("juice")` resolves to `client.js` when using browserify and webpack.