### PR TITLE
Addressing paths without test coverage

### DIFF
--- a/lib/selector.js
+++ b/lib/selector.js
@@ -71,7 +71,7 @@ Selector.prototype.specificity = function () {
         spec[3] += pseudos.length;
 
         for (var p = 0; p < pseudos.length; p++) {
-         if (pseudos[p].key === 'not'){
+         if (pseudos[p].name === 'not'){
             nots.push(pseudos[p].value);
             spec[3]--;
           }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ var cssom = require('cssom');
 var cheerio = require('cheerio');
 var own = {}.hasOwnProperty;
 var os = require('os');
-var util = require('util');
+var deprecate = require('util-deprecate');
 var Selector = require('./selector');
 var Property = require('./property');
 
@@ -198,7 +198,7 @@ exports.decodeEntities = function(html){
  * @api public
  */
 
-exports.toArray = util.deprecate( function (arr) {
+exports.toArray = deprecate( function (arr) {
   var ret = [];
 
   for (var i = 0, l = arr.length; i < l; i++){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,7 @@ var cssom = require('cssom');
 var cheerio = require('cheerio');
 var own = {}.hasOwnProperty;
 var os = require('os');
+var util = require('util');
 var Selector = require('./selector');
 var Property = require('./property');
 
@@ -197,7 +198,7 @@ exports.decodeEntities = function(html){
  * @api public
  */
 
-exports.toArray = function (arr) {
+exports.toArray = util.deprecate( function (arr) {
   var ret = [];
 
   for (var i = 0, l = arr.length; i < l; i++){
@@ -205,7 +206,7 @@ exports.toArray = function (arr) {
   }
 
   return ret;
-};
+}, 'utils.toArray: Will be removed in a future version' );
 
 /**
  * Compares two specificity vectors, returning the winning one.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commander": "2.9.0",
     "cssom": "0.3.0",
     "slick": "1.12.2",
+    "util-deprecate": "^1.0.2",
     "web-resource-inliner": "1.2.1"
   },
   "devDependencies": {

--- a/test/cases/juice-content/pseudo-elements.html
+++ b/test/cases/juice-content/pseudo-elements.html
@@ -34,8 +34,14 @@ b:after {
 b :last-child {
   color: red;
 }
+
+c:not(.not) {
+    color: red;
+}
 </style>
 <a href="#">Test</a>
 <b></b>
 <b><span></span></b>
+<c></c>
+<c class="not"></c>
 </body></html>

--- a/test/cases/juice-content/pseudo-elements.out
+++ b/test/cases/juice-content/pseudo-elements.out
@@ -3,4 +3,6 @@
 <a href="#" style="text-decoration: underline; color: blue;"><span>®+</span>Test<span style="font-weight: bold;">a</span></a>
 <b><span style="color: green;">b</span></b>
 <b><span style="color: red;"></span><span style="color: green;">b</span></b>
+<c style="color: red;"></c>
+<c class="not"></c>
 </body></html>

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -66,6 +66,8 @@ it('selector specificity calculator', function () {
     assert.deepEqual(spec('[type=text]'), [0, 0, 1, 0]);
     assert.deepEqual(spec('*'),[0, 0, 0, 0]);
     assert.deepEqual(spec('div *'),[0, 0, 0, 1]);
+    assert.deepEqual(spec('div.a.b'),[0, 0, 2, 1]);
+    assert.deepEqual(spec('div:not(.a):not(.b)'),[0, 0, 2, 1]);
 } );
 
 it('property comparison based on selector specificity', function () {

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -89,6 +89,12 @@ it('property comparison based on selector specificity', function () {
     assert.deepEqual(a.compare(b),b);
 } );
 
+it('property toString', function () {
+    var a = new Property('color', 'white', new Selector('#woot'));
+
+    assert.equal(a.toString(), "color: white;");
+} );
+
 it('parse simple css into a object structure', function () {
     var parse = utils.parseCSS;
 


### PR DESCRIPTION
- Deprecates `utils.toArray()` which is not used internally and is essentially useless as an external API
- Adds test coverage for `toString()` which is also not used internally, but looks like it could be useful externally
- Fixes specificity for `:not()` selectors, in particular that slick was not being used correctly so `:not()` was previously never found. This change is semver-minor. 