### PR TITLE
CLI refresh

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+1.8.0 / Pending
+==================
+
+* Make all options available through CLI
+* Make CLI tests work on Windows
+* Deprecate `utils.toArray()`
+* Fix handling of `:not()` specificity
+
 1.7.0 / 2015-11-03
 ==================
 

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 ==================
 
 * Make all options available through CLI
+* Add `--options-file` to CLI for loading JSON options
 * Make CLI tests work on Windows
 * Deprecate `utils.toArray()`
 * Fix handling of `:not()` specificity

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The CLI should have all the above [options](#options) with the names changed fro
 These are additional options not included in the standard `juice` options listed above:
 
 - `--css [filepath]` will load and inject CSS into `extraCss`.
+- `--options-file [filepath]` will load and inject options from a JSON file. Options from the CLI will be given priority over options in the file when there is a conflict.
 
 ### Running Juice in the Browser
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,15 @@ This can be used to embed email client support hacks that rely on css selectors 
 
 To use Juice from CLI, run `juice [options] input.html output.html`
 
-Current CLI options:
+For a listing of all available options, just type `juice -h`.
+
+> Note that if you want to just type `juice` from the command line, you should `npm install juice -g` so it is globally available.
+
+CLI Options:
+
+The CLI should have all the above [options](#options) with the names changed from camel case to hyphen-delimited, so for example `extraCss` becomes `extra-css` and `webResources.scripts` becomes `web-resources-scripts`.
+
+These are additional options not included in the standard `juice` options listed above:
 
 - `--css [filepath]` will load and inject CSS into `extraCss`.
 

--- a/bin/juice
+++ b/bin/juice
@@ -2,52 +2,51 @@
 
 var juice = require('..');
 var cli = require('../lib/cli');
-var program = require('commander');
-var package = require('../package');
+var xtend = require('xtend');
 var fs = require('fs');
+var path = require('path');
 
-program.name = package.name;
-
-program.version(package.version)
-  .usage('[options] input.html output.html');
-
-Object.keys(cli.options).forEach( function (key) {
-    program.option('--' + key + ' [value]', cli.options[key].def);
-});
-
-program.parse(process.argv);
+var program = cli.getProgram();
 
 if (program.args < 2) program.help();
 
-var inputFile = program.args[0]
-  , outputFile = program.args[1]
-  , options = cli.argsToOptions(program)
-  , waitingOn = 1;
+var inputFile = program.args[0];
+var outputFile = program.args[1];
+var options = cli.argsToOptions(program);
+var queue = [];
+
+if (options.optionsFile) {
+    var optionsFromFile = require(path.join(process.cwd(),options.optionsFile));
+    options = xtend(optionsFromFile, options);
+}
 
 if (options.cssFile) {
-  var cssFile = options.cssFile;
-  delete options.cssFile;
-  waitingOn++;
-  fs.readFile(cssFile, function (err, css) {
-    if (handleError(err)) { return; }
-    options.extraCss = css;
-    next();
+  queue.push( function () {
+      fs.readFile(options.cssFile, function (err, css) {
+        if (handleError(err)) { return; }
+        options.extraCss = css;
+        next();
+      });
   });
 }
 
 next();
 
 function doJuice() {
+  delete options.cssFile;
+  delete options.optionsFile;
+
   juice.juiceFile(inputFile, options, function(err, html) {
     if (handleError(err)) { return; }
     fs.writeFile(outputFile, html, handleError);
   });
 }
 
-function next(err) {
-  if (handleError(err)) { return; }
-  waitingOn--;
-  if (waitingOn <= 0) { doJuice(); }
+function next() {
+  if (queue.length) {
+      return queue.pop()();
+  }
+  doJuice();
 }
 
 function handleError(err) {
@@ -55,5 +54,5 @@ function handleError(err) {
     console.error(err.stack);
     process.exit(1);
   }
-  return err ? true : false;
+  return !!err;
 }

--- a/bin/juice
+++ b/bin/juice
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var juice = require('..');
+var cli = require('../lib/cli');
 var program = require('commander');
 var package = require('../package');
 var fs = require('fs');
@@ -8,20 +9,26 @@ var fs = require('fs');
 program.name = package.name;
 
 program.version(package.version)
-  .usage('[options] input.html output.html')
-  .option('--css [filepath]', 'Add an extra CSS file')
-  .parse(process.argv);
+  .usage('[options] input.html output.html');
+
+Object.keys(cli.options).forEach( function (key) {
+    program.option('--' + key + ' [value]', cli.options[key].def);
+});
+
+program.parse(process.argv);
 
 if (program.args < 2) program.help();
 
 var inputFile = program.args[0]
   , outputFile = program.args[1]
-  , options = {}
+  , options = cli.argsToOptions(program)
   , waitingOn = 1;
 
-if (program.css) {
+if (options.cssFile) {
+  var cssFile = options.cssFile;
+  delete options.cssFile;
   waitingOn++;
-  fs.readFile(program.css, function (err, css) {
+  fs.readFile(cssFile, function (err, css) {
     if (handleError(err)) { return; }
     options.extraCss = css;
     next();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,79 @@
+"use strict";
+
+var cli = {};
+
+module.exports = cli;
+
+cli.options = {
+    "css": {
+        map: "cssFile",
+        def: "Add an extra CSS file by name" },
+    "extra-css": {
+        map: "extraCss",
+        def: "Add extra CSS" },
+    "apply-style-tags": {
+        map: "applyStyleTags",
+        def: "inline from style tags?" },
+    "remove-style-tags": {
+        map: "removeStyleTags",
+        def: "remove style tags?" },
+    "preserve-media-queries": {
+        map: "preserveMediaQueries",
+        def: "preserve media queries?" },
+    "preserve-font-faces": {
+        map: "preserveFontFaces",
+        def: "preserve media queries?" },
+    "apply-width-attributes": {
+        map: "applyWidthAttributes",
+        def: "apply width attributes to relevent elements?" },
+    "apply-height-attributes": {
+        map: "applyHeightAttributes",
+        def: "apply width attributes to relevent elements?" },
+    "apply-attributes-table-elements": {
+        map: "applyAttributesTableElements",
+        def: "apply attributes with and equivalent CSS value to table elemets?" },
+    "web-resources-inline-attribute": {
+        map: "webResources.inlineAttribute",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-images": {
+        map: "webResources.images",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-links": {
+        map: "webResources.links",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-scripts": {
+        map: "webResources.scripts",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-relative-to": {
+        map: "webResources.relativeTo",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-rebase-relative-to": {
+        map: "webResources.rebaseRelativeTo",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-cssmin": {
+        map: "webResources.cssmin",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-uglify": {
+        map: "webResources.uglify",
+        def: "see docs for web-resource-inliner" },
+    "web-resources-strict": {
+        map: "webResources.strict",
+        def: "see docs for web-resource-inliner" }
+};
+
+cli.argsToOptions = function (program) {
+    var result = { webResources: {} };
+    Object.keys(cli.options).forEach(function (key) {
+        if(typeof(program[key]) !== "undefined") {
+            var option = cli.options[key];
+            var value = program[key];
+            if(key.match(/web-resources/)) {
+                result.webResources[option.map.replace(/webResources\./, "")] = value;
+            }
+            else {
+                result[option.map] = value;
+            }
+        }
+    } );
+    return result;
+};

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,77 +1,108 @@
 "use strict";
 
+var program = require('commander');
+var pkg = require('../package');
+
 var cli = {};
 
 module.exports = cli;
 
+cli.getProgram = function () {
+    program.name = pkg.name;
+
+    program.version(pkg.version)
+      .usage('[options] input.html output.html');
+
+    Object.keys(cli.options).forEach( function (key) {
+        program.option('--' + key + ' [value]', cli.options[key].def);
+    });
+
+    program.parse(process.argv);
+
+    return program;
+};
+
 cli.options = {
     "css": {
+        pMap: "css",
         map: "cssFile",
         def: "Add an extra CSS file by name" },
+    "options-file": {
+        pMap: "optionsFile",
+        def: "Load options from a JSON file" },
     "extra-css": {
-        map: "extraCss",
+        pMap: "extraCss",
         def: "Add extra CSS" },
     "apply-style-tags": {
-        map: "applyStyleTags",
+        pMap: "applyStyleTags",
         def: "inline from style tags?" },
     "remove-style-tags": {
-        map: "removeStyleTags",
+        pMap: "removeStyleTags",
         def: "remove style tags?" },
     "preserve-media-queries": {
-        map: "preserveMediaQueries",
+        pMap: "preserveMediaQueries",
         def: "preserve media queries?" },
     "preserve-font-faces": {
-        map: "preserveFontFaces",
+        pMap: "preserveFontFaces",
         def: "preserve media queries?" },
     "apply-width-attributes": {
-        map: "applyWidthAttributes",
+        pMap: "applyWidthAttributes",
         def: "apply width attributes to relevent elements?" },
     "apply-height-attributes": {
-        map: "applyHeightAttributes",
+        pMap: "applyHeightAttributes",
         def: "apply width attributes to relevent elements?" },
     "apply-attributes-table-elements": {
-        map: "applyAttributesTableElements",
+        pMap: "applyAttributesTableElements",
         def: "apply attributes with and equivalent CSS value to table elemets?" },
     "web-resources-inline-attribute": {
-        map: "webResources.inlineAttribute",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesInlineAttribute",
+        map: "inlineAttribute",
+        def: "see docs for web-resource-inliner inlineAttribute" },
     "web-resources-images": {
-        map: "webResources.images",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesImages",
+        map: "images",
+        def: "see docs for web-resource-inliner images" },
     "web-resources-links": {
-        map: "webResources.links",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesLinks",
+        map: "links",
+        def: "see docs for web-resource-inliner links" },
     "web-resources-scripts": {
-        map: "webResources.scripts",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesScripts",
+        map: "scripts",
+        def: "see docs for web-resource-inliner scripts" },
     "web-resources-relative-to": {
-        map: "webResources.relativeTo",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesRelativeTo",
+        map: "relativeTo",
+        def: "see docs for web-resource-inliner relativeTo" },
     "web-resources-rebase-relative-to": {
-        map: "webResources.rebaseRelativeTo",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesRebaseRelativeTo",
+        map: "rebaseRelativeTo",
+        def: "see docs for web-resource-inliner rebaseRelativeTo" },
     "web-resources-cssmin": {
-        map: "webResources.cssmin",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesCssmin",
+        map: "cssmin",
+        def: "see docs for web-resource-inliner cssmin" },
     "web-resources-uglify": {
-        map: "webResources.uglify",
-        def: "see docs for web-resource-inliner" },
+        pMap: "webResourcesUglify",
+        map: "uglify",
+        def: "see docs for web-resource-inliner uglify" },
     "web-resources-strict": {
-        map: "webResources.strict",
-        def: "see docs for web-resource-inliner" }
+        pMap: "webResourcesStrict",
+        map: "strict",
+        def: "see docs for web-resource-inliner strict" }
 };
 
 cli.argsToOptions = function (program) {
     var result = { webResources: {} };
     Object.keys(cli.options).forEach(function (key) {
-        if(typeof(program[key]) !== "undefined") {
-            var option = cli.options[key];
-            var value = program[key];
-            if(key.match(/web-resources/)) {
-                result.webResources[option.map.replace(/webResources\./, "")] = value;
+        var option = cli.options[key];
+        var value = program[option.pMap];
+        if (value !== undefined) {            
+            if (option.pMap.match(/webResources/)) {
+                result.webResources[option.map] = value;
             }
             else {
-                result[option.map] = value;
+                result[option.map || option.pMap] = value;
             }
         }
     } );

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "slick": "1.12.2",
     "util-deprecate": "^1.0.2",
     "web-resource-inliner": "1.2.1",
-    "win-spawn": "^2.0.0"
+    "win-spawn": "^2.0.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "should": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "cssom": "0.3.0",
     "slick": "1.12.2",
     "util-deprecate": "^1.0.2",
-    "web-resource-inliner": "1.2.1"
+    "web-resource-inliner": "1.2.1",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "should": "4.0.4",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,11 +1,34 @@
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
-var spawn = require('child_process').spawn;
+var spawn = require('win-spawn');
+var cli = require('../lib/cli');
 
 before(function () {
   if (fs.existsSync('tmp')) { return; }
   fs.mkdirSync('tmp');
+});
+
+it('cli parses options', function (done) {
+  assert.strictEqual(cli.argsToOptions({css:"file.css"}).cssFile, "file.css");
+  assert.strictEqual(cli.argsToOptions({"extra-css":"body{color:red;}"}).extraCss, "body{color:red;}");
+  assert.strictEqual(cli.argsToOptions({"apply-style-tags":true}).applyStyleTags, true);
+  assert.strictEqual(cli.argsToOptions({"remove-style-tags":true}).removeStyleTags, true);
+  assert.strictEqual(cli.argsToOptions({"preserve-media-queries":true}).preserveMediaQueries, true);
+  assert.strictEqual(cli.argsToOptions({"preserve-font-faces":true}).preserveFontFaces, true);
+  assert.strictEqual(cli.argsToOptions({"apply-width-attributes":true}).applyWidthAttributes, true);
+  assert.strictEqual(cli.argsToOptions({"apply-height-attributes":true}).applyHeightAttributes, true);
+  assert.strictEqual(cli.argsToOptions({"apply-attributes-table-elements":true}).applyAttributesTableElements, true);
+  assert.strictEqual(cli.argsToOptions({"web-resources-inline-attribute":true}).webResources.inlineAttribute, true);
+  assert.strictEqual(cli.argsToOptions({"web-resources-images":12}).webResources.images, 12);
+  assert.strictEqual(cli.argsToOptions({"web-resources-links":true}).webResources.links, true);
+  assert.strictEqual(cli.argsToOptions({"web-resources-scripts":24}).webResources.scripts, 24);
+  assert.strictEqual(cli.argsToOptions({"web-resources-relative-to":"web"}).webResources.relativeTo, "web");
+  assert.strictEqual(cli.argsToOptions({"web-resources-rebase-relative-to":"root"}).webResources.rebaseRelativeTo, "root");
+  assert.strictEqual(cli.argsToOptions({"web-resources-cssmin":true}).webResources.cssmin, true);
+  assert.strictEqual(cli.argsToOptions({"web-resources-uglify":true}).webResources.uglify, true);
+  assert.strictEqual(cli.argsToOptions({"web-resources-strict":true}).webResources.strict, true);
+  done();
 });
 
 it('cli no css', function (done) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,24 +10,25 @@ before(function () {
 });
 
 it('cli parses options', function (done) {
-  assert.strictEqual(cli.argsToOptions({css:"file.css"}).cssFile, "file.css");
-  assert.strictEqual(cli.argsToOptions({"extra-css":"body{color:red;}"}).extraCss, "body{color:red;}");
-  assert.strictEqual(cli.argsToOptions({"apply-style-tags":true}).applyStyleTags, true);
-  assert.strictEqual(cli.argsToOptions({"remove-style-tags":true}).removeStyleTags, true);
-  assert.strictEqual(cli.argsToOptions({"preserve-media-queries":true}).preserveMediaQueries, true);
-  assert.strictEqual(cli.argsToOptions({"preserve-font-faces":true}).preserveFontFaces, true);
-  assert.strictEqual(cli.argsToOptions({"apply-width-attributes":true}).applyWidthAttributes, true);
-  assert.strictEqual(cli.argsToOptions({"apply-height-attributes":true}).applyHeightAttributes, true);
-  assert.strictEqual(cli.argsToOptions({"apply-attributes-table-elements":true}).applyAttributesTableElements, true);
-  assert.strictEqual(cli.argsToOptions({"web-resources-inline-attribute":true}).webResources.inlineAttribute, true);
-  assert.strictEqual(cli.argsToOptions({"web-resources-images":12}).webResources.images, 12);
-  assert.strictEqual(cli.argsToOptions({"web-resources-links":true}).webResources.links, true);
-  assert.strictEqual(cli.argsToOptions({"web-resources-scripts":24}).webResources.scripts, 24);
-  assert.strictEqual(cli.argsToOptions({"web-resources-relative-to":"web"}).webResources.relativeTo, "web");
-  assert.strictEqual(cli.argsToOptions({"web-resources-rebase-relative-to":"root"}).webResources.rebaseRelativeTo, "root");
-  assert.strictEqual(cli.argsToOptions({"web-resources-cssmin":true}).webResources.cssmin, true);
-  assert.strictEqual(cli.argsToOptions({"web-resources-uglify":true}).webResources.uglify, true);
-  assert.strictEqual(cli.argsToOptions({"web-resources-strict":true}).webResources.strict, true);
+  assert.strictEqual(cli.argsToOptions({"css":"file.css"}).cssFile, "file.css");
+  assert.strictEqual(cli.argsToOptions({"optionsFile":"options.json"}).optionsFile, "options.json");
+  assert.strictEqual(cli.argsToOptions({"extraCss":"body{color:red;}"}).extraCss, "body{color:red;}");
+  assert.strictEqual(cli.argsToOptions({"applyStyleTags":true}).applyStyleTags, true);
+  assert.strictEqual(cli.argsToOptions({"removeStyleTags":true}).removeStyleTags, true);
+  assert.strictEqual(cli.argsToOptions({"preserveMediaQueries":true}).preserveMediaQueries, true);
+  assert.strictEqual(cli.argsToOptions({"preserveFontFaces":true}).preserveFontFaces, true);
+  assert.strictEqual(cli.argsToOptions({"applyWidthAttributes":true}).applyWidthAttributes, true);
+  assert.strictEqual(cli.argsToOptions({"applyHeightAttributes":true}).applyHeightAttributes, true);
+  assert.strictEqual(cli.argsToOptions({"applyAttributesTableElements":true}).applyAttributesTableElements, true);
+  assert.strictEqual(cli.argsToOptions({"webResourcesInlineAttribute":true}).webResources.inlineAttribute, true);
+  assert.strictEqual(cli.argsToOptions({"webResourcesImages":12}).webResources.images, 12);
+  assert.strictEqual(cli.argsToOptions({"webResourcesLinks":true}).webResources.links, true);
+  assert.strictEqual(cli.argsToOptions({"webResourcesScripts":24}).webResources.scripts, 24);
+  assert.strictEqual(cli.argsToOptions({"webResourcesRelativeTo":"web"}).webResources.relativeTo, "web");
+  assert.strictEqual(cli.argsToOptions({"webResourcesRebaseRelativeTo":"root"}).webResources.rebaseRelativeTo, "root");
+  assert.strictEqual(cli.argsToOptions({"webResourcesCssmin":true}).webResources.cssmin, true);
+  assert.strictEqual(cli.argsToOptions({"webResourcesUglify":true}).webResources.uglify, true);
+  assert.strictEqual(cli.argsToOptions({"webResourcesStrict":true}).webResources.strict, true);
   done();
 });
 
@@ -56,6 +57,25 @@ it('cli css included', function (done) {
   var outputPath = 'tmp/integration.out';
 
   var juiceProcess = spawn('bin/juice', [htmlPath, '--css', cssPath, outputPath]);
+
+  juiceProcess.on('error', done);
+
+  juiceProcess.on('exit', function (code) {
+    assert(code === 0, 'Expected exit code to be 0');
+    var output = fs.readFileSync(outputPath, 'utf8');
+    var expectedOutput = fs.readFileSync(expectedPath, 'utf8');
+    assert.equal(output, expectedOutput);
+    done();
+  });
+});
+
+it('cli options included', function (done) {
+  var htmlPath = 'test/cases/juice-content/font-face-preserve.html';
+  var optionsFilePath = 'test/cases/juice-content/font-face-preserve.json';
+  var expectedPath = 'test/cases/juice-content/font-face-preserve.out';
+  var outputPath = 'tmp/font-face-preserve.out';
+
+  var juiceProcess = spawn('bin/juice', [htmlPath, '--options-file', optionsFilePath, outputPath]);
 
   juiceProcess.on('error', done);
 


### PR DESCRIPTION
CLI supports all juice options as well as supporting loading options from a JSON file. CLI tests also pass on Windows finally.

Replaces #126 and #174 

/cc @niek