### PR TITLE
Add a functionality to exclude css properties from inliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Array of table HTML elements that can receive attributes defined in `juice.style
 
 Array of elements that will not have styles inlined because they are not intended to render.
 
+#### juiceClient.excludedProperties
+
+Array of css properties that won't be inlined.
+
 ### Special markup
 
 #### data-embed

--- a/client.js
+++ b/client.js
@@ -163,8 +163,9 @@ function inlineDocument($, css, options) {
           var prop = new utils.Property(name, value, sel);
           var existing = el.styleProps[name];
 
-          if (existing && existing.compare(prop) === prop && !/\!important$/.test(existing.value) || !existing) {
-            if(juiceClient.excludedProperties.indexOf(name) < 0){
+          // if property name is not in the excluded properties array
+          if(juiceClient.excludedProperties.indexOf(name) < 0){
+            if (existing && existing.compare(prop) === prop && !/\!important$/.test(existing.value) || !existing) {
               el.styleProps[name] = prop;
             }
           }

--- a/client.js
+++ b/client.js
@@ -27,6 +27,7 @@ juiceClient.styleToAttribute = {
   'text-align': 'align',
   'vertical-align': 'valign'
 };
+juiceClient.excludedProperties = [];
 
 juiceClient.juiceDocument = juiceDocument;
 juiceClient.inlineDocument = inlineDocument;
@@ -163,7 +164,9 @@ function inlineDocument($, css, options) {
           var existing = el.styleProps[name];
 
           if (existing && existing.compare(prop) === prop && !/\!important$/.test(existing.value) || !existing) {
-            el.styleProps[name] = prop;
+            if(juiceClient.excludedProperties.indexOf(name) < 0){
+              el.styleProps[name] = prop;
+            }
           }
         }
       }

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -130,6 +130,17 @@ it('parse complex css into a object structure', function () {
     assert.deepEqual(bed[1],cab[1]);
 } );
 
+it('test excludedProperties setting', function () {
+    juice.excludedProperties = ['-webkit-font-smoothing'];
+    assert.deepEqual(
+        juice(
+            '<div a="b">woot</div>',
+            {extraCss: 'div { color: blue; -webkit-font-smoothing: antialiased; }'}
+        ),
+        '<div a="b" style="color: blue;">woot</div>'
+    );
+} );
+
 it('test juice', function () {
     assert.deepEqual(juice('<div a="b">woot</div>', {extraCss: 'div { color: red; }'}),
         '<div a="b" style="color: red;">woot</div>');

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -139,6 +139,8 @@ it('test excludedProperties setting', function () {
         ),
         '<div a="b" style="color: blue;">woot</div>'
     );
+    // reset global setting
+    juice.excludedProperties = [];
 } );
 
 it('test juice', function () {


### PR DESCRIPTION
It happens in some projects that I had the necessity to not inline some properties, usually for email templates.

For instance:
<pre>* {
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
}</pre>

With this commit I added another global variable, `juiceClient.excludedProperties`, in which the user can specify the properties that he doesn't want to inline.

For instance:
<pre>[
    '-webkit-font-smoothing',
    '-moz-osx-font-smoothing'
]</pre>

Can it be useful?

Cheers,
Raffaele

