### PR TITLE
specificity fixes, dep updates, changes to option defaults, 2.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,10 @@
-2.0.0 / 2016-05-23
+2.0.0 / 2016-05-24
 ==================
 
 * fix: specificity bugs
 * deps: upgrade cheerio, cssom, web-resource-inliner
 * major: most options default to `true` instead of `false` now
+* major: remove deprecated `toArray`
 
 1.11.0 / 2016-05-11
 ==================

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+2.0.0 / 2016-05-23
+==================
+
+* fix: specificity bugs
+* deps: upgrade cheerio, cssom, web-resource-inliner
+* major: most options default to `true` instead of `false` now
+
 1.11.0 / 2016-05-11
 ==================
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ All juice methods take an options object that can contain any of these propertie
  * `extraCss` - extra css to apply to the file. Defaults to `""`.
  * `applyStyleTags` - whether to inline styles in `<style></style>` Defaults to `true`.
  * `removeStyleTags` - whether to remove the original `<style></style>` tags after (possibly) inlining the css from them. Defaults to `true`.
- * `preserveMediaQueries` - preserves all media queries (and contained styles) within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. Defaults to `false`.
- * `preserveFontFaces` - preserves all `@font-face` within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. Defaults to `false`.
- * `insertPreservedExtraCss` - whether to insert into the document any preserved `@media` or `@font-face` content from `extraCss` when using `preserveMediaQueries` or `preserveFontFaces`. When `true` order of preference to append the `<style>` element is into `head`, then `body`, then at the end of the document. When a `string` the value is treated as a CSS/jQuery/cheerio selector, and when found, the `<style>` tag will be appended to the end of the first match. Defaults to `false`.
- * `applyWidthAttributes` - whether to use any CSS pixel widths to create `width` attributes on elements set in `juice.widthElements`. Defaults to `false`.
- * `applyHeightAttributes` - whether to use any CSS pixel heights to create `height` attributes on elements set in `juice.heightElements`. Defaults to `false`.
- * `applyAttributesTableElements` - whether to create attributes for styles in `juice.styleToAttribute` on elements set in `juice.tableElements`. Defaults to `false`.
+ * `preserveMediaQueries` - preserves all media queries (and contained styles) within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. Defaults to `true`.
+ * `preserveFontFaces` - preserves all `@font-face` within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. Defaults to `true`.
+ * `insertPreservedExtraCss` - whether to insert into the document any preserved `@media` or `@font-face` content from `extraCss` when using `preserveMediaQueries` or `preserveFontFaces`. When `true` order of preference to append the `<style>` element is into `head`, then `body`, then at the end of the document. When a `string` the value is treated as a CSS/jQuery/cheerio selector, and when found, the `<style>` tag will be appended to the end of the first match. Defaults to `true`.
+ * `applyWidthAttributes` - whether to use any CSS pixel widths to create `width` attributes on elements set in `juice.widthElements`. Defaults to `true`.
+ * `applyHeightAttributes` - whether to use any CSS pixel heights to create `height` attributes on elements set in `juice.heightElements`. Defaults to `true`.
+ * `applyAttributesTableElements` - whether to create attributes for styles in `juice.styleToAttribute` on elements set in `juice.tableElements`. Defaults to `true`.
  * `webResources` - An options object that will be passed to [web-resource-inliner](https://www.npmjs.com/package/web-resource-inliner) for juice functions that will get remote resources (`juiceResources` and `juiceFile`). Defaults to `{}`.
  * `inlinePseudoElements` - Whether to insert pseudo elements (`::before` and `::after`) as `<span>` into the DOM. *Note*: Inserting pseudo elements will modify the DOM and may conflict with CSS selectors elsewhere on the page (e.g., `:last-child`).
  * `xmlMode` - whether to output XML/XHTML with all tags closed. Note that the input *must* also be valid XML/XHTML or you will get undesirable results. Defaults to `false`.

--- a/bin/juice
+++ b/bin/juice
@@ -24,7 +24,7 @@ if (options.cssFile) {
   queue.push(function() {
     fs.readFile(options.cssFile, function(err, css) {
       if (handleError(err)) { return; }
-      options.extraCss = css;
+      options.extraCss = css.toString();
       next();
     });
   });

--- a/client.js
+++ b/client.js
@@ -140,7 +140,7 @@ function inlineDocument($, css, options) {
         // if the element has inline styles, fake selector with topmost specificity
         if ($(el).attr('style')) {
           var cssText = '* { ' + $(el).attr('style') + ' } ';
-          addProps(utils.parseCSS(cssText)[0][1], utils.styleSelector);
+          addProps(utils.parseCSS(cssText)[0][1], new utils.Selector('<style>', true));
         }
 
         // store reference to an element we need to compile style="" attr for
@@ -152,14 +152,12 @@ function inlineDocument($, css, options) {
         for (var i = 0, l = style.length; i < l; i++) {
           var name = style[i];
           var value = style[name] + (options.preserveImportant && style._importants[name] ? ' !important' : '');
-          var prop = new utils.Property(name, value, selector);
-          var priority = style._importants[name] ? 2 : 0;
+          var prop = new utils.Property(name, value, selector, style._importants[name] ? 2 : 0);
           var existing = el.styleProps[name];
 
           // if property name is not in the excluded properties array
           if (juiceClient.excludedProperties.indexOf(name) < 0) {
-            if (existing && existing.compare(prop, priority) === prop && !/\!important$/.test(existing.value)
-                || !existing) {
+            if (existing && existing.compare(prop) === prop || !existing) {
               el.styleProps[name] = prop;
             }
           }

--- a/lib/property.js
+++ b/lib/property.js
@@ -17,10 +17,11 @@ var utils = require('./utils');
  * @api public
  */
 
-function Property(prop, value, selector) {
+function Property(prop, value, selector, priority) {
   this.prop = prop;
   this.value = value;
   this.selector = selector;
+  this.priority = priority || 0;
 }
 
 /**
@@ -29,9 +30,11 @@ function Property(prop, value, selector) {
  * @api public
  */
 
-Property.prototype.compare = function(property, priority) {
-  var a = this.selector.specificity(priority);
-  var b = property.selector.specificity(priority);
+Property.prototype.compare = function(property) {
+  var a = this.selector.specificity();
+  a[0] += this.priority;
+  var b = property.selector.specificity();
+  b[0] += property.priority;
   var winner = utils.compare(a, b);
 
   if (winner === a && a !== b) {

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -12,9 +12,10 @@ module.exports = exports = Selector;
  * @api public
  */
 
-function Selector(text, spec) {
+function Selector(text, styleAttribute) {
   this.text = text;
-  this.spec = spec;
+  this.spec = undefined;
+  this.styleAttribute = styleAttribute || false;
 }
 
 /**
@@ -34,14 +35,14 @@ Selector.prototype.parsed = function() {
  * @api public
  */
 
-Selector.prototype.specificity = function(priority) {
-  priority = priority || 0; // 1 = style tag, 2 = !important
+Selector.prototype.specificity = function() {
+  var styleAttribute = this.styleAttribute;
   if (!this.spec) { this.spec = specificity(this.text, this.parsed()); }
   return this.spec;
 
   function specificity(text, parsed) {
     var expressions = parsed || parse(text);
-    var spec = [priority, 0, 0, 0];
+    var spec = [styleAttribute ? 1 : 0, 0, 0, 0];
     var nots = [];
 
     for (var i = 0; i < expressions.length; i++) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,6 @@ var Property = require('./property');
 
 exports.Selector = Selector;
 exports.Property = Property;
-exports.styleSelector = new Selector('<style attribute>', [1, 0, 0, 0]);
 
 /**
  * Returns an array of the selectors.
@@ -232,13 +231,14 @@ exports.extend = function(obj, src) {
 exports.getDefaultOptions = function(options) {
   var result = exports.extend({
     extraCss: '',
+    insertPreservedExtraCss: true,
     applyStyleTags: true,
     removeStyleTags: true,
-    preserveMediaQueries: false,
-    preserveFontFaces: false,
-    applyWidthAttributes: false,
-    applyHeightAttributes: false,
-    applyAttributesTableElements: false,
+    preserveMediaQueries: true,
+    preserveFontFaces: true,
+    applyWidthAttributes: true,
+    applyHeightAttributes: true,
+    applyAttributesTableElements: true,
     url: ''
   }, options);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,6 @@ var cssom = require('cssom');
 var cheerio = require('cheerio');
 var own = {}.hasOwnProperty;
 var os = require('os');
-var deprecate = require('util-deprecate');
 var Selector = require('./selector');
 var Property = require('./property');
 
@@ -184,21 +183,6 @@ exports.decodeEntities = function(html) {
   return exports.decodeEJS(html);
 };
 
-/**
- * Converts to array
- *
- * @api public
- */
-
-exports.toArray = deprecate(function(arr) {
-  var ret = [];
-
-  for (var i = 0, l = arr.length; i < l; i++) {
-    ret.push(arr[i]);
-  }
-
-  return ret;
-}, 'utils.toArray: Will be removed in a future version');
 
 /**
  * Compares two specificity vectors, returning the winning one.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juice",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "description": "Inlines css into html source",
   "bin": "bin/juice",
   "main": "index.js",
@@ -37,14 +37,14 @@
   },
   "dependencies": {
     "batch": "0.5.3",
-    "cheerio": "0.19.0",
+    "cheerio": "0.20.0",
     "commander": "2.9.0",
     "cross-spawn-async": "^2.1.8",
-    "cssom": "0.3.0",
+    "cssom": "0.3.1",
     "deep-extend": "^0.4.0",
     "slick": "1.12.2",
     "util-deprecate": "^1.0.2",
-    "web-resource-inliner": "1.2.1"
+    "web-resource-inliner": "2.0.0"
   },
   "devDependencies": {
     "should": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "cssom": "0.3.1",
     "deep-extend": "^0.4.0",
     "slick": "1.12.2",
-    "util-deprecate": "^1.0.2",
     "web-resource-inliner": "2.0.0"
   },
   "devDependencies": {

--- a/test/cases/juice-content/font-face-preserve.json
+++ b/test/cases/juice-content/font-face-preserve.json
@@ -1,5 +1,6 @@
 {
     "url": "./",
     "removeStyleTags": true,
-    "preserveFontFaces": true
+    "preserveFontFaces": true,
+    "preserveMediaQueries": false
 }

--- a/test/cases/juice-content/media-preserve.json
+++ b/test/cases/juice-content/media-preserve.json
@@ -3,5 +3,6 @@
     "removeStyleTags": true,
     "preserveMediaQueries": true,
     "insertPreservedExtraCss": true,
+    "preserveFontFaces": false,
     "extraCss": "@media all { body { color: blue; } }"
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -59,7 +59,7 @@ it('cli css included', function(done) {
   var expectedPath = 'test/cases/integration.out';
   var outputPath = 'tmp/integration.out';
 
-  var juiceProcess = spawn('bin/juice', [htmlPath, '--css', cssPath, outputPath]);
+  var juiceProcess = spawn('bin/juice', [htmlPath, '--css', cssPath, '--apply-width-attributes', 'false', outputPath]);
 
   juiceProcess.on('error', done);
 
@@ -84,7 +84,7 @@ it('cli options included', function(done) {
 
   juiceProcess.on('exit', function(code) {
     assert(code === 0, 'Expected exit code to be 0');
-    var output = fs.readFileSync(outputPath, 'utf8');
+    var output = fs.readFileSync(outputPath, 'utf8').replace(/\r/g, '');
     var expectedOutput = fs.readFileSync(expectedPath, 'utf8');
     assert.equal(output, expectedOutput);
     done();

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -53,8 +53,8 @@ it('selector specificity comparison', function() {
 });
 
 it('selector specificity calculator', function() {
-  function spec(selector, priority) {
-    return new Selector(selector).specificity(priority);
+  function spec(selector) {
+    return new Selector(selector).specificity();
   }
 
   assert.deepEqual(spec('#test'),[0, 1, 0, 0]);
@@ -68,9 +68,6 @@ it('selector specificity calculator', function() {
   assert.deepEqual(spec('div *'),[0, 0, 0, 1]);
   assert.deepEqual(spec('div.a.b'),[0, 0, 2, 1]);
   assert.deepEqual(spec('div:not(.a):not(.b)'),[0, 0, 2, 1]);
-
-  assert.deepEqual(spec('#test', 1),[1, 1, 0, 0]);
-  assert.deepEqual(spec('#test', 2),[2, 1, 0, 0]);
 });
 
 it('property comparison based on selector specificity', function() {
@@ -156,4 +153,29 @@ it('test consecutive important rules', function() {
   assert.deepEqual(
     juice.inlineContent('<p><a>woot</a></p>', 'p a {color: red !important;} a {color: black !important;}'),
       '<p><a style="color: red;">woot</a></p>');
+});
+
+it('test * specificity', function() {
+  assert.deepEqual(
+      juice.inlineContent('<div class="a"></div><div class="b"></div>',
+          '* { margin: 0; padding: 0; } .b { margin: 0 !important; } .a { padding: 20px; }'),
+      '<div class="a" style="margin: 0; padding: 20px;"></div><div class="b" style="padding: 0; margin: 0;"></div>');
+});
+
+it('test style attributes priority', function() {
+  assert.deepEqual(
+      juice.inlineContent('<div style="color: red;"></div>', 'div { color: black; }'),
+      '<div style="color: red;"></div>');
+});
+
+it('test style attributes and important priority', function() {
+  assert.deepEqual(
+      juice.inlineContent('<div style="color: red;"></div>', 'div { color: black !important; }'),
+      '<div style="color: black;"></div>');
+});
+
+it('test style attributes and important priority', function() {
+  assert.deepEqual(
+      juice.inlineContent('<div style="color: red !important;"></div>', 'div { color: black !important; }'),
+      '<div style="color: red;"></div>');
 });


### PR DESCRIPTION
fixes #210 
resolves #190 

Notes on breaking changes:
- The specificity fixes in here should be minor or unnoticed for most users
- The upgraded web-resource-inliner will inline small SVGs by default, that can be disabled/adjusted through options. See https://www.npmjs.com/package/web-resource-inliner
- The changes to several of the default values might be undesirable for some use cases, so you may want to change these explicitly to `false` in the options for preserveMediaQueries, preserveFontFaces, insertPreservedExtraCss, applyWidthAttributes, applyHeightAttributes, applyAttributesTableElements. There were all added in the 1.x lifetime and initially set to `false` to avoid breaking changes, but for most cases, particularly emails, these should usually all be set to true. If inlining HTML fragments for non-email use, it is likely that you want to turn off some or all of these.