### PR TITLE
Expose `--xml-mode` in cli

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -65,6 +65,10 @@ cli.options = {
     pMap: 'applyAttributesTableElements',
     def: 'apply attributes with and equivalent CSS value to table elements?',
     coercion: JSON.parse },
+  'xml-mode': {
+    pMap: 'xmlMode',
+    def: 'generate output with tags closed?  input must be valid XML',
+    coercion: JSON.parse },
   'web-resources-inline-attribute': {
     pMap: 'webResourcesInlineAttribute',
     map: 'inlineAttribute',

--- a/test/cli.js
+++ b/test/cli.js
@@ -23,6 +23,7 @@ it('cli parses options', function(done) {
   assert.strictEqual(cli.argsToOptions({'applyWidthAttributes': 'true'}).applyWidthAttributes, true);
   assert.strictEqual(cli.argsToOptions({'applyHeightAttributes': 'true'}).applyHeightAttributes, true);
   assert.strictEqual(cli.argsToOptions({'applyAttributesTableElements': 'true'}).applyAttributesTableElements, true);
+  assert.strictEqual(cli.argsToOptions({'xmlMode': 'true'}).xmlMode, true);
   assert.strictEqual(cli.argsToOptions({'webResourcesInlineAttribute': 'true'}).webResources.inlineAttribute, true);
   assert.strictEqual(cli.argsToOptions({'webResourcesImages': '12'}).webResources.images, 12);
   assert.strictEqual(cli.argsToOptions({'webResourcesLinks': 'true'}).webResources.links, true);


### PR DESCRIPTION
Added this to enable `xmlMode` for batch jobs on SVG documents.  Perhaps it's useful?