### PR TITLE
Add a functionality to not inline certain css rules ( with [dontInline] attribute )

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -16,6 +16,7 @@ juiceClient.styleToAttribute = {
   'vertical-align': 'valign'
 };
 juiceClient.excludedProperties = [];
+juiceClient.dontInlineRegex = /\[dontInline\]/g;
 
 juiceClient.juiceDocument = juiceDocument;
 juiceClient.inlineDocument = inlineDocument;
@@ -76,6 +77,13 @@ function inlineDocument($, css, options) {
   function handleRule(rule) {
     var sel = rule[0];
     var style = rule[1];
+
+    // if the selector contains the [dontInline] attribute,
+    // stop its inlining process
+    if(sel.match(juiceClient.dontInlineRegex)){
+      return false;
+    }
+
     var selector = new utils.Selector(sel);
     var parsedSelector = selector.parsed();
     var pseudoElementType = getPseudoElementType(parsedSelector);
@@ -342,6 +350,10 @@ function getStylesData($, options) {
       } else {
         $(styleElement).remove();
       }
+    } else {
+      // if removeStyleTags is not selected, remove [dontInline] attribute from the classes
+      // in the outputted style in order to make the selector work
+      styleDataList[0].data = styleData.replace(juiceClient.dontInlineRegex, '');
     }
     $(styleElement).removeAttr('data-embed');
   });

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -186,3 +186,12 @@ it('test style attributes and important priority', function() {
       juice.inlineContent('<div style="color: red !important;"></div>', 'div { color: black !important; }'),
       '<div style="color: red;"></div>');
 });
+
+it('test [dontInline] attribute', function() {
+  assert.deepEqual(
+      juice(
+          '<style>div[dontInline] { color: blue;}</style><div a="b">woot</div>'
+      , {removeStyleTags : false}),
+      '<style>div { color: blue;}</style><div a="b">woot</div>'
+  );
+});


### PR DESCRIPTION
Hello guys

It happened to me to have the necessity to not inline some particular rule of my css. A solution to this could to add a **[dontInline]** attribute in the selector name.

es. 

```
.very-generic-selector[dontInline] {
   padding:0;
}
```

In this way, in the style this would be translated in

```
<style>
    .very-generic-selector {
       padding:0;
    }
</style>
```

and my `<div class="very-generic-selector">content</div>` would not get any inlined style **from that css rule**.

What do you think?

Cheers
