### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage
 npm-debug.log
 tmp
+test/typescript/*.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for your interest. Before opening an issue or pull request please review 
 - If you'd like to report a bug please reproduce it in [Tonic](https://tonicdev.com/npm/juice) and include the link in the issue
 - Pull requests must have test coverage and pass on Travis
 - Feature changes should have accompanying documentation updates
+- API changes should be also reflected in `juice.d.ts` and `juice-tests.ts` files
 - JavaScript standards are defined in the .jscsrc file, please maintain those standards when making changes. The standards are a relaxed version of the Node.js standards.
 
 That's the main stuff, thanks!

--- a/juice.d.ts
+++ b/juice.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for Juice 3.0.0
+// Project: https://github.com/Automattic/juice
+// Definitions by: Kamil Nikel <https://github.com/knikel>
+
+/* =================== USAGE ===================
+   import juice = require('juice');
+   =============================================== */
+
+/// <reference types="cheerio" />
+
+export = juice;
+
+declare function juice(html: string, options?: juice.Options): string;
+
+declare namespace juice {
+
+  export function juiceResources(html: string, options: Options, callback: Callback): string
+
+  export function juiceFile(filePath: string, options: Options, callback: Callback): string
+
+  export function juiceDocument($: CheerioStatic, options?: Options): CheerioStatic
+
+  export function inlineContent(html: string, css: string, options?: Options): string
+
+  export function inlineDocument($: CheerioStatic, css: string, options?: Options): CheerioStatic
+
+  export let ignoredPseudos: string[];
+  export let widthElements: HTMLElement[];
+  export let heightElements: HTMLElement[];
+  export let styleToAttribute: { [index: string]: string };
+  export let tableElements: HTMLElement[];
+  export let nonVisualElements: HTMLElement[];
+  export let excludedProperties: string[];
+
+  export interface Callback { (err: Error, html: string): any; }
+
+  interface Options {
+    extraCss?: string;
+    applyStyleTags?: boolean;
+    removeStyleTags?: boolean;
+    preserveMediaQueries?: boolean;
+    preserveFontFaces?: boolean;
+    insertPreservedExtraCss?: boolean;
+    applyWidthAttributes?: boolean;
+    applyHeightAttributes?: boolean;
+    applyAttributesTableElements?: boolean;
+    webResources?: WebResourcesOptions;
+    inlinePseudoElements?: boolean;
+    xmlMode?: boolean;
+    preserveImportant?: boolean;
+  }
+
+  interface WebResourcesOptions {
+    fileContent: string;
+    inlineAttribute?: string;
+    images?: boolean | number;
+    svgs?: boolean | number;
+    scripts?: boolean | number;
+    links?: boolean | number;
+    relativeTo?: string;
+    rebaseRelativeTo?: string;
+    cssmin?: boolean;
+    strict?: boolean;
+  }
+}

--- a/juice.d.ts
+++ b/juice.d.ts
@@ -6,8 +6,6 @@
    import juice = require('juice');
    =============================================== */
 
-/// <reference types="cheerio" />
-
 export = juice;
 
 declare function juice(html: string, options?: juice.Options): string;
@@ -18,11 +16,11 @@ declare namespace juice {
 
   export function juiceFile(filePath: string, options: Options, callback: Callback): string
 
-  export function juiceDocument($: CheerioStatic, options?: Options): CheerioStatic
+  export function juiceDocument($: any, options?: Options): any
 
   export function inlineContent(html: string, css: string, options?: Options): string
 
-  export function inlineDocument($: CheerioStatic, css: string, options?: Options): CheerioStatic
+  export function inlineDocument($: any, css: string, options?: Options): any
 
   export let ignoredPseudos: string[];
   export let widthElements: HTMLElement[];

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "main": "index.js",
   "browser": "client.js",
   "scripts": {
-    "test": "mocha --reporter spec",
-    "testcover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+    "test": "mocha --reporter spec && npm run test-typescript",
+    "testcover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
+    "test-typescript": "tsc ./test/typescript/juice-tests.ts && rm ./test/typescript/juice-tests.js"
   },
   "license": "MIT",
   "contributors": [
@@ -35,7 +36,9 @@
   "engines": {
     "node": ">=4.0.0"
   },
+  "types": "juice.d.ts",
   "dependencies": {
+    "@types/cheerio": "^0.17.31",
     "cheerio": "0.20.0",
     "commander": "2.9.0",
     "cross-spawn": "^4.0.0",
@@ -45,9 +48,10 @@
     "web-resource-inliner": "3.0.0"
   },
   "devDependencies": {
-    "should": "4.0.4",
+    "batch": "0.5.3",
     "mocha": "1.21.4",
-    "batch": "0.5.3"
+    "should": "4.0.4",
+    "typescript": "^2.0.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "types": "juice.d.ts",
   "dependencies": {
-    "@types/cheerio": "^0.17.31",
     "cheerio": "0.20.0",
     "commander": "2.9.0",
     "cross-spawn": "^4.0.0",

--- a/test/typescript/cheerio.d.ts
+++ b/test/typescript/cheerio.d.ts
@@ -1,0 +1,5 @@
+declare var cheerio: any;
+
+declare module 'cheerio' {
+  export = cheerio;
+}

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -1,0 +1,148 @@
+import juice = require('../../');
+import cheerio = require('cheerio');
+
+const sample = '<style>div{class: red;}</style><div></div>';
+const someHtml = '<h1 class="x">yo</h1>';
+const someCss = '.x{font-size: 20em;}';
+const noOptions = {};
+const mostOptions = {
+  extraCss: someCss,
+  applyStyleTags: true,
+  removeStyleTags: true,
+  preserveMediaQueries: true,
+  preserveFontFaces: true,
+  insertPreservedExtraCss: true,
+  applyWidthAttributes: true,
+  applyHeightAttributes: true,
+  applyAttributesTableElements: true,
+  inlinePseudoElements: true,
+  xmlMode: true,
+  preserveImportant: true,
+};
+const minWebResourceOptions = {
+  webResources: {
+    fileContent: '<link href="css/style.css" rel="stylesheet">',
+  },
+};
+const allWebResourceOptions = {
+  webResources: {
+    fileContent: '<link href="css/style.css" rel="stylesheet" inlineme>',
+    inlineAttribute: 'inlineme',
+    images: true,
+    svgs: true,
+    scripts: true,
+    links: true,
+    relativeTo: 'https://github.com/',
+    rebaseRelativeTo: 'assets',
+    cssmin: true,
+    strict: true,
+  },
+};
+
+const cheerio$ = cheerio.load('<h1>test</h1>');
+
+const x: string = juice(someHtml, {});
+
+juice.juiceResources(
+  sample,
+  noOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceResources(
+  sample,
+  mostOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceResources(
+  sample,
+  minWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceResources(
+  sample,
+  allWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceResources(
+  sample,
+  { extraCss: 'body{background: red;}' },
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceFile(
+  'somePath.html',
+  noOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceFile(
+  'somePath.html',
+  mostOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceFile(
+  'somePath.html',
+  minWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceFile(
+  'somePath.html',
+  allWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+const c1: CheerioStatic = juice.juiceDocument(
+  cheerio$,
+  noOptions
+);
+
+const c2: CheerioStatic = juice.juiceDocument(
+  cheerio$,
+  mostOptions
+);
+
+const c3: CheerioStatic = juice.juiceDocument(
+  cheerio$,
+  minWebResourceOptions
+);
+
+const c4: CheerioStatic = juice.juiceDocument(
+  cheerio$,
+  allWebResourceOptions
+);
+
+const c5: CheerioStatic = juice.juiceDocument(
+  cheerio$,
+);
+
+juice.inlineContent(someHtml, someCss, noOptions);
+
+juice.inlineContent(someHtml, someCss, mostOptions);
+
+juice.inlineContent(someHtml, someCss, minWebResourceOptions);
+
+juice.inlineContent(someHtml, someCss, allWebResourceOptions);
+
+juice.inlineDocument(cheerio$, someCss, noOptions);
+
+juice.inlineDocument(cheerio$, someCss, mostOptions);
+
+juice.inlineDocument(cheerio$, someCss, minWebResourceOptions);
+
+juice.inlineDocument(cheerio$, someCss, allWebResourceOptions);
+
+// Global settings
+
+juice.ignoredPseudos = ['hover'];
+juice.widthElements = [];
+juice.heightElements = [];
+juice.styleToAttribute = { x: 'y' };
+juice.tableElements = [];
+juice.nonVisualElements = [];
+juice.excludedProperties = [];

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -1,3 +1,7 @@
+// This file should be updated when `cheerio` has type definitions
+
+/// <reference path="./cheerio.d.ts" />
+
 import juice = require('../../');
 import cheerio = require('cheerio');
 
@@ -97,27 +101,27 @@ juice.juiceFile(
   (err: Error, html: string): void => console.log(html)
 );
 
-const c1: CheerioStatic = juice.juiceDocument(
+const c1 = juice.juiceDocument(
   cheerio$,
   noOptions
 );
 
-const c2: CheerioStatic = juice.juiceDocument(
+const c2 = juice.juiceDocument(
   cheerio$,
   mostOptions
 );
 
-const c3: CheerioStatic = juice.juiceDocument(
+const c3 = juice.juiceDocument(
   cheerio$,
   minWebResourceOptions
 );
 
-const c4: CheerioStatic = juice.juiceDocument(
+const c4 = juice.juiceDocument(
   cheerio$,
   allWebResourceOptions
 );
 
-const c5: CheerioStatic = juice.juiceDocument(
+const c5 = juice.juiceDocument(
   cheerio$,
 );
 


### PR DESCRIPTION
### Changes
* Add `juice.d.ts` file
* Add `juice-tests.ts` file where whole API is used
* Add `types` entry to `package.json` pointing to the definitions file
* Add `typescript` devDependency and `@types/cheerio` dependency, since `juice` relies on `cheerio` library.
* Add note to `CONTRIBUTING.md`

### Questions
* Is the location for `juice-tests.ts` OK? (`tests/typescript/juice-tests.ts`)
* Is the location for `juice.d.ts` OK? (project root)
