### PR TITLE
Allow newer versions of Cheerio, current one is broken.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "types": "juice.d.ts",
   "dependencies": {
-    "cheerio": "0.20.0",
+    "cheerio": "^0.22.0",
     "commander": "2.9.0",
     "cross-spawn": "^4.0.0",
     "mensch": "^0.3.3",


### PR DESCRIPTION
The `0.20.0` version of Cheerio you depend on has a typo bug which makes it unimportable via its `index.js`. This has been fixed in [this commit](https://github.com/cheeriojs/cheerio/commit/7b59afbc7a6aa39376021593e011bf718350bcb4) and released in their `0.21.0` release. 

Unfortunately, Juice is hard depended on that old version. This is totally breaking our application right now but using the new version of Cheerio fixes it.