### PR TITLE
Add juice.codeBlocks to TypeScript type definitions

### DIFF
--- a/juice.d.ts
+++ b/juice.d.ts
@@ -22,13 +22,14 @@ declare namespace juice {
 
   export function inlineDocument($: any, css: string, options?: Options): any
 
-  export let ignoredPseudos: string[];
-  export let widthElements: HTMLElement[];
+  export let codeBlocks: {start: string, end: string};
+  export let excludedProperties: string[];
   export let heightElements: HTMLElement[];
+  export let ignoredPseudos: string[];
+  export let nonVisualElements: HTMLElement[];
   export let styleToAttribute: { [index: string]: string };
   export let tableElements: HTMLElement[];
-  export let nonVisualElements: HTMLElement[];
-  export let excludedProperties: string[];
+  export let widthElements: HTMLElement[];
 
   export interface Callback { (err: Error, html: string): any; }
 

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -143,6 +143,7 @@ juice.inlineDocument(cheerio$, someCss, allWebResourceOptions);
 
 // Global settings
 
+juice.codeBlocks = {start: '{{', end: '}}'};
 juice.ignoredPseudos = ['hover'];
 juice.widthElements = [];
 juice.heightElements = [];


### PR DESCRIPTION
Since there is a new API in `v4.*`, I've updated the TypeScript type definitions file with the new API.

## Changes
* Add `juice.codeBlocks` option to type definitions
* Add `juice.codeBlocks` usage to `juice-tests.ts`
* Sort `juice` options alphabetically in type definitions file