### PR TITLE
Remove ES6 lambda feature occurrences

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -14,7 +14,7 @@ var cheerioLoad = function(html, options) {
 
 var encodeCodeBlocks = function(html) {
   var blocks = module.exports.codeBlocks;
-  Object.keys(blocks).forEach((key) => {
+  Object.keys(blocks).forEach(function(key) {
     var re = new RegExp(blocks[key].start + '((.|\\s)*?)' + blocks[key].end, 'g');
     html = html.replace(re, function(match, subMatch) {
       return '<!--' + key + ' ' + blocks[key].start + subMatch + blocks[key].end + ' -->';
@@ -25,7 +25,7 @@ var encodeCodeBlocks = function(html) {
 
 var decodeCodeBlocks = function(html) {
   var blocks = module.exports.codeBlocks;
-  Object.keys(blocks).forEach((key) => {
+  Object.keys(blocks).forEach(function(key) {
     var re = new RegExp('<!--' + key + ' ' + blocks[key].start + '((.|\\s)*?)' + blocks[key].end + ' -->', 'g');
     html = html.replace(re, function(match, subMatch) {
       return blocks[key].start + subMatch + blocks[key].end;


### PR DESCRIPTION
Hello guys,

Currently, the code contains ES6 lambda usage. Because of this, while using a bundler (e.g. Webpack) it's required to use "babel" for this particular lib only. Usually it's not required, so it would be good not to expose "node_modules" to "babel" at all. 

Since the app already uses anonymous functions, there should not be any problems with the proposed change.