### PR TITLE
Retain the original order of preserved text. Fixes #255.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,7 +95,7 @@ exports.getPreservedText = function(css, options) {
   for (var i = rules.length - 1; i >= 0; i--) {
     if ((options.fontFaces && rules[i].type === 'font-face') ||
         (options.mediaQueries && rules[i].type === 'media')) {
-      preserved.push(
+      preserved.unshift(
         mensch.stringify(
           { stylesheet: { rules: [ rules[i] ] }},
           { comments: false, indentation: '  ' }

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -186,3 +186,9 @@ it('test style attributes and important priority', function() {
       juice.inlineContent('<div style="color: red !important;"></div>', 'div { color: black !important; }'),
       '<div style="color: red;"></div>');
 });
+
+it('test that preserved text order is stable', function() {
+  assert.deepEqual(
+      utils.getPreservedText('div { color: red; } @media (min-width: 320px) { div { color: green; } } @media (max-width: 640px) { div { color: blue; } }', { mediaQueries: true }).replace(/\s+/g, ' '),
+      ' @media (min-width: 320px) { div { color: green; } } @media (max-width: 640px) { div { color: blue; } } ');
+});


### PR DESCRIPTION
## Issue

Per https://github.com/Automattic/juice/issues/255, since `utils.getPreservedText` iterates over the rules in reverse order and pushes preserved items onto an array, the order of those preserved items is flipped. This causes CSS precedence issues in the final output.

## Proposed Solution

We move from `Array.push` to `Array.unshift` for the preserved text, retaining the source order.