### PR TITLE
Bugfix: double quotes in table style attributes

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -248,8 +248,10 @@ function inlineDocument($, css, options) {
     }
   }
 
-  function replaceQuotes(value) {
-    return value.replace(/"/g, "'");
+  function extractBackgroundUrl(value) {
+    return value.indexOf('url(') !== 0
+      ? value
+      : value.replace(/^url\((["'])?([^"']+)\1\)$/, '$2');
   }
 
   function setAttributesOnTableElements(el) {
@@ -260,7 +262,12 @@ function inlineDocument($, css, options) {
     if (juiceClient.tableElements.indexOf(elName) > -1) {
       for (var i in el.styleProps) {
         if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
-          $(el).attr(juiceClient.styleToAttribute[el.styleProps[i].prop], replaceQuotes(el.styleProps[i].value));
+          var prop = juiceClient.styleToAttribute[el.styleProps[i].prop];
+          var value = el.styleProps[i].value;
+          if (prop === 'background') {
+            value = extractBackgroundUrl(value)
+          }
+          $(el).attr(prop, value);
         }
       }
     }

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -248,6 +248,10 @@ function inlineDocument($, css, options) {
     }
   }
 
+  function replaceQuotes(value) {
+    return value.replace(/"/g, "'");
+  }
+
   function setAttributesOnTableElements(el) {
     if (!el.name) { return; }
     var elName = el.name.toUpperCase();
@@ -256,7 +260,7 @@ function inlineDocument($, css, options) {
     if (juiceClient.tableElements.indexOf(elName) > -1) {
       for (var i in el.styleProps) {
         if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
-          $(el).attr(juiceClient.styleToAttribute[el.styleProps[i].prop], el.styleProps[i].value);
+          $(el).attr(juiceClient.styleToAttribute[el.styleProps[i].prop], replaceQuotes(el.styleProps[i].value));
         }
       }
     }

--- a/test/cases/juice-content/table-attr.html
+++ b/test/cases/juice-content/table-attr.html
@@ -10,6 +10,10 @@
             background-image: url('test.png');
             background-color: red;
         }
+
+        td {
+            background-image: url("test.png");
+        }
     </style>
 </head>
 <body>

--- a/test/cases/juice-content/table-attr.html
+++ b/test/cases/juice-content/table-attr.html
@@ -11,8 +11,16 @@
             background-color: red;
         }
 
-        td {
+        td.double {
             background-image: url("test.png");
+        }
+
+        td.single {
+            background-image: url('test.png');
+        }
+
+        td.none {
+            background-image: url(test.png);
         }
     </style>
 </head>
@@ -20,7 +28,13 @@
     <p>none</p>
     <table>
         <tr>
-            <td>
+            <td class="double">
+                wide
+            </td>
+            <td class="single">
+                wide
+            </td>
+            <td class="none">
                 wide
             </td>
         </tr>

--- a/test/cases/juice-content/table-attr.out
+++ b/test/cases/juice-content/table-attr.out
@@ -4,9 +4,15 @@
 </head>
 <body>
     <p style="text-align: center; vertical-align: middle;">none</p>
-    <table style="background-image: url('test.png'); background-color: red;" background="url('test.png')" bgcolor="red">
+    <table style="background-image: url('test.png'); background-color: red;" background="test.png" bgcolor="red">
         <tr>
-            <td style="text-align: center; vertical-align: middle; background-image: url('test.png');" align="center" valign="middle" background="url('test.png')">
+            <td class="double" style="text-align: center; vertical-align: middle; background-image: url('test.png');" align="center" valign="middle" background="test.png">
+                wide
+            </td>
+            <td class="single" style="text-align: center; vertical-align: middle; background-image: url('test.png');" align="center" valign="middle" background="test.png">
+                wide
+            </td>
+            <td class="none" style="text-align: center; vertical-align: middle; background-image: url(test.png);" align="center" valign="middle" background="test.png">
                 wide
             </td>
         </tr>

--- a/test/cases/juice-content/table-attr.out
+++ b/test/cases/juice-content/table-attr.out
@@ -6,7 +6,7 @@
     <p style="text-align: center; vertical-align: middle;">none</p>
     <table style="background-image: url('test.png'); background-color: red;" background="url('test.png')" bgcolor="red">
         <tr>
-            <td style="text-align: center; vertical-align: middle;" align="center" valign="middle">
+            <td style="text-align: center; vertical-align: middle; background-image: url('test.png');" align="center" valign="middle" background="url('test.png')">
                 wide
             </td>
         </tr>


### PR DESCRIPTION
Example:

```html
<style>
  td { background-image: url("test.png"); }
</style>
<td>Foobar</td>
```

Without this fix results in broken HTML:

```html
<style>
  td { background-image: url("test.png"); }
</style>
<td style="background-image: url('test.png');" background="url(" test.png")"="">Foobar</td>
```

After fix:

```html
<style>
  td { background-image: url("test.png"); }
</style>
<td style="background-image: url('test.png');" background="url('test.png')">Foobar</td>
```