### PR TITLE
Fixed typing of codeBlocks to match documentation

### DIFF
--- a/juice.d.ts
+++ b/juice.d.ts
@@ -22,7 +22,7 @@ declare namespace juice {
 
   export function inlineDocument($: any, css: string, options?: Options): any
 
-  export let codeBlocks: {start: string, end: string};
+  export let codeBlocks: { [index: string]: { start: string, end: string } };
   export let excludedProperties: string[];
   export let heightElements: HTMLElement[];
   export let ignoredPseudos: string[];

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -143,7 +143,7 @@ juice.inlineDocument(cheerio$, someCss, allWebResourceOptions);
 
 // Global settings
 
-juice.codeBlocks = {start: '{{', end: '}}'};
+juice.codeBlocks.HBS = { start: '{{', end: '}}' };
 juice.ignoredPseudos = ['hover'];
 juice.widthElements = [];
 juice.heightElements = [];


### PR DESCRIPTION
The typing was a bit off for codeBlocks which made this option difficult to use with Typescript. It was expecting a single value like `juice.codeBlocks = {start: '{{', end: '}}'}` rather than the actual format, `juice.codeBlocks.HBS = {start: '{{', end: '}}'}`.