### PR TITLE
Add notifme-template to "Projects using juice" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ result will be:
 * [node-email-templates][1] - Node.js module for rendering beautiful emails with [ejs][2] templates and email-friendly inline CSS using [juice][3].
 * [swig-email-templates][4] - Uses [swig][5], which gives you [template inheritance][6], and can generate a [dummy context][7] from a template.
 * [nodejs-api-starter][8] - A project template for building web APIs with Node.js and GraphQL (see [`src/emails`][9]).
+* [notifme-template][10] - A Node.js library to easily handle all your notification (`emails` | `SMS` | `pushes` | `webpushes`) templates. (can be used in combination with [`notifme-sdk`][11]).
 
 [1]: https://github.com/niftylettuce/node-email-templates
 [2]: https://github.com/tj/ejs
@@ -43,6 +44,8 @@ result will be:
 [7]: https://github.com/andrewrk/swig-dummy-context
 [8]: https://github.com/kriasoft/nodejs-api-starter
 [9]: https://github.com/kriasoft/nodejs-api-starter/tree/master/src/emails
+[10]: https://github.com/notifme/notifme-template
+[11]: https://github.com/notifme/notifme-sdk
 
 ## Documentation
 


### PR DESCRIPTION
Hi, I added this project https://github.com/notifme/notifme-template to "Projects using juice" section. It's a subproject of https://github.com/notifme/notifme-sdk