### PR TITLE
Use regex that does not catastrophically backtrack

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -15,7 +15,7 @@ var cheerioLoad = function(html, options) {
 var encodeCodeBlocks = function(html) {
   var blocks = module.exports.codeBlocks;
   Object.keys(blocks).forEach(function(key) {
-    var re = new RegExp(blocks[key].start + '((.|\\s)*?)' + blocks[key].end, 'g');
+    var re = new RegExp(blocks[key].start + '([\\S\\s]*?)' + blocks[key].end, 'g');
     html = html.replace(re, function(match, subMatch) {
       return '<!--' + key + ' ' + blocks[key].start + subMatch + blocks[key].end + ' -->';
     });

--- a/test/cases/ejs-unterminated.css
+++ b/test/cases/ejs-unterminated.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/test/cases/ejs-unterminated.html
+++ b/test/cases/ejs-unterminated.html
@@ -1,0 +1,3 @@
+<body>
+<div class="<% foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz"></div>
+</body>

--- a/test/cases/ejs-unterminated.out
+++ b/test/cases/ejs-unterminated.out
@@ -1,0 +1,3 @@
+<body style="color: red;">
+<div class="<% foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz"></div>
+</body>

--- a/test/cases/hbs-unterminated.css
+++ b/test/cases/hbs-unterminated.css
@@ -1,0 +1,4 @@
+body,
+p {
+  color: red;
+}

--- a/test/cases/hbs-unterminated.html
+++ b/test/cases/hbs-unterminated.html
@@ -1,0 +1,3 @@
+<body>
+{{ foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz
+</body>

--- a/test/cases/hbs-unterminated.out
+++ b/test/cases/hbs-unterminated.out
@@ -1,0 +1,3 @@
+<body style="color: red;">
+{{ foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz
+</body>


### PR DESCRIPTION
The nested quantifier used in the encodeCodeBlocks regex can
catastrophically backtrack when it encounters unterminated ejs or hbs
tags. Fixes #260