### PR TITLE
update TS definition to allow for optional fileContent option

### DIFF
--- a/juice.d.ts
+++ b/juice.d.ts
@@ -50,7 +50,7 @@ declare namespace juice {
   }
 
   interface WebResourcesOptions {
-    fileContent: string;
+    fileContent?: string;
     inlineAttribute?: string;
     images?: boolean | number;
     svgs?: boolean | number;

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -24,8 +24,11 @@ const mostOptions = {
   preserveImportant: true,
 };
 const minWebResourceOptions = {
+  webResources: {},
+};
+const someWebResourceOptions = {
   webResources: {
-    fileContent: '<link href="css/style.css" rel="stylesheet">',
+    images: false,
   },
 };
 const allWebResourceOptions = {
@@ -67,6 +70,12 @@ juice.juiceResources(
 
 juice.juiceResources(
   sample,
+  someWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceResources(
+  sample,
   allWebResourceOptions,
   (err: Error, html: string): void => console.log(html)
 );
@@ -97,6 +106,12 @@ juice.juiceFile(
 
 juice.juiceFile(
   'somePath.html',
+  someWebResourceOptions,
+  (err: Error, html: string): void => console.log(html)
+);
+
+juice.juiceFile(
+  'somePath.html',
   allWebResourceOptions,
   (err: Error, html: string): void => console.log(html)
 );
@@ -118,10 +133,15 @@ const c3 = juice.juiceDocument(
 
 const c4 = juice.juiceDocument(
   cheerio$,
-  allWebResourceOptions
+  someWebResourceOptions
 );
 
 const c5 = juice.juiceDocument(
+  cheerio$,
+  allWebResourceOptions
+);
+
+const c6 = juice.juiceDocument(
   cheerio$,
 );
 
@@ -131,6 +151,8 @@ juice.inlineContent(someHtml, someCss, mostOptions);
 
 juice.inlineContent(someHtml, someCss, minWebResourceOptions);
 
+juice.inlineContent(someHtml, someCss, someWebResourceOptions);
+
 juice.inlineContent(someHtml, someCss, allWebResourceOptions);
 
 juice.inlineDocument(cheerio$, someCss, noOptions);
@@ -138,6 +160,8 @@ juice.inlineDocument(cheerio$, someCss, noOptions);
 juice.inlineDocument(cheerio$, someCss, mostOptions);
 
 juice.inlineDocument(cheerio$, someCss, minWebResourceOptions);
+
+juice.inlineDocument(cheerio$, someCss, someWebResourceOptions);
 
 juice.inlineDocument(cheerio$, someCss, allWebResourceOptions);
 


### PR DESCRIPTION
The current TypeScript definitions disallow a use case that I think is intended to be used.  Right now when applying web-resources-inliner options, the code defaults the value for `fileContent`

see `juice/index.js:55`:
```
function inlineExternal(html, inlineOptions, callback) {
  var options = utils.extend({fileContent: html}, inlineOptions);
  inline.html(options, callback);
}
```

As written currently, the TS interface for these options makes `fileContent` required.  That means that the defaulting behavior above is only used if no other options are set.  However if I want to do something like disable image inlining, i'd have to pass the `fileContent` option, meaning I'd be passing the html value twice in the same call.

This PR makes the `fileContent` option optional, so if it is not included, it will default to the html that it would use in the case where no options are passed.

I added some tests that ensure that the functions that take these options still compile in the case described.

Since this doesn't change the functionality of the library itself, just the compilation ability, I didn't think there were any other tests to add, please let me know if there's more I can do.