### PR TITLE
Fix memory leak in cheerio code block encode/decode

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -6,42 +6,41 @@
 var cheerio = require('cheerio');
 var utils = require('./utils');
 
-var cheerioLoad = function(html, options) {
+var cheerioLoad = function(html, options, encodeEntities) {
   options = utils.extend({decodeEntities: false}, options || {});
   html = encodeEntities(html);
   return cheerio.load(html,options);
 };
 
-var codeBlockLookup = [];
+var createEntityConverters = function () {
+  var codeBlockLookup = [];
 
-var encodeCodeBlocks = function(html) {
-  var blocks = module.exports.codeBlocks;
-  Object.keys(blocks).forEach(function(key) {
-    var re = new RegExp(blocks[key].start + '([\\S\\s]*?)' + blocks[key].end, 'g');
-    html = html.replace(re, function(match, subMatch) {
-      codeBlockLookup.push(match); 
-      return 'JUICE_CODE_BLOCK_' + (codeBlockLookup.length - 1) + '_';
+  var encodeCodeBlocks = function(html) {
+    var blocks = module.exports.codeBlocks;
+    Object.keys(blocks).forEach(function(key) {
+      var re = new RegExp(blocks[key].start + '([\\S\\s]*?)' + blocks[key].end, 'g');
+      html = html.replace(re, function(match, subMatch) {
+        codeBlockLookup.push(match);
+        return 'JUICE_CODE_BLOCK_' + (codeBlockLookup.length - 1) + '_';
+      });
     });
-  });
-  return html;
-};
+    return html;
+  };
 
-var decodeCodeBlocks = function(html) {
-  for(var index = 0; index < codeBlockLookup.length; index++) {    
-    var re = new RegExp('JUICE_CODE_BLOCK_' + index + '_(="")?', 'gi');
-    html = html.replace(re, function() {
-      return codeBlockLookup[index];
-    });
-  }
-  return html;
-};
+  var decodeCodeBlocks = function(html) {
+    for(var index = 0; index < codeBlockLookup.length; index++) {
+      var re = new RegExp('JUICE_CODE_BLOCK_' + index + '_(="")?', 'gi');
+      html = html.replace(re, function() {
+        return codeBlockLookup[index];
+      });
+    }
+    return html;
+  };
 
-var encodeEntities = function(html) {
-  return encodeCodeBlocks(html);
-};
-
-var decodeEntities = function(html) {
-  return decodeCodeBlocks(html);
+  return {
+    encodeEntities: encodeCodeBlocks,
+    decodeEntities: decodeCodeBlocks,
+  };
 };
 
 /**
@@ -54,7 +53,9 @@ var decodeEntities = function(html) {
  * @return {String} resulting html
  */
 module.exports = function(html, options, callback, callbackExtraArguments) {
-  var $ = cheerioLoad(html, options);
+  var entityConverters = createEntityConverters();
+
+  var $ = cheerioLoad(html, options, entityConverters.encodeEntities);
   var args = [ $ ];
   args.push.apply(args, callbackExtraArguments);
   var doc = callback.apply(undefined, args) || $;
@@ -62,7 +63,7 @@ module.exports = function(html, options, callback, callbackExtraArguments) {
   if (options && options.xmlMode) {
     return doc.xml();
   }
-  return decodeEntities(doc.html());
+  return entityConverters.decodeEntities(doc.html());
 };
 
 module.exports.codeBlocks = {


### PR DESCRIPTION
Allow the variable `codeBlockLookup` to be dropped out of scope so that each time `juice` is run it does not accrue more code block lookups (which is a memory leak).