### PR TITLE
Include extension when requiring package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  */
 
 var utils = require('./lib/utils');
-var packageJson = require('./package');
+var packageJson = require('./package.json');
 var fs = require('fs');
 var path = require('path');
 var inline = require('web-resource-inliner');


### PR DESCRIPTION
When using TypeScript to load `juice`, the current import does not work properly because it implies the extension `.json`. Explicitly adding the extension makes the library more portable.

closes #303