### PR TITLE
Add Dovetailer to projects list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ result will be:
 * [mosaico][13] - The first opensource email template editor. Helps you build responsive and appealing email templates in few clicks.
 * [mjml][12] - A markup language designed for painless responsive email coding. The markup gets transpiled to HTML that works in any email client.
 * [maizzle][14] - A utility-first CSS-based framework for rapid email development.
+* [dovetailer][15] - Use Sass and Nunjucks to generate HTML emails with text versions, optimized for all email clients and ready to send. A [starter project][16] is also available.
 
 [1]: https://github.com/niftylettuce/node-email-templates
 [2]: https://github.com/tj/ejs
@@ -52,6 +53,8 @@ result will be:
 [12]: https://github.com/mjmlio/mjml
 [13]: https://github.com/voidlabs/mosaico
 [14]: https://github.com/ThemeMountain/maizzle
+[15]: https://github.com/maxlapides/dovetailer
+[16]: https://github.com/maxlapides/dovetailer-starter
 
 ## Documentation
 


### PR DESCRIPTION
After developing HTML emails for about a decade, I decided to start a side project with the idea that I could automate away a lot of the annoyance of writing emails. I've been working on this project for a number of years now, and after using it for a while at my new company, I feel confident that it's ready to show the world.

My goal in building this project is to empower developers who are used to working with modern web tech to quickly build HTML emails without having to worry about the massive slew of hacks and gotchas typically involved in building emails. I want to empower developers to build without constraints, and without being overly opinionated. Dovetailer is not a framework, it is a compiler.

I have also provided a starter repository, which is closer to a framework. I would encourage getting started by forking the starter repository and making it your own!