### PR TITLE
Remove duplicate TD in juiceClient.tableElements

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -7,7 +7,7 @@ module.exports = function makeJuiceClient(juiceClient) {
 juiceClient.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
 juiceClient.widthElements = ['TABLE', 'TD', 'TH', 'IMG'];
 juiceClient.heightElements = ['TABLE', 'TD', 'TH', 'IMG'];
-juiceClient.tableElements = ['TABLE', 'TD', 'TH', 'TR', 'TD', 'CAPTION', 'COLGROUP', 'COL', 'THEAD', 'TBODY', 'TFOOT'];
+juiceClient.tableElements = ['TABLE', 'TH', 'TR', 'TD', 'CAPTION', 'COLGROUP', 'COL', 'THEAD', 'TBODY', 'TFOOT'];
 juiceClient.nonVisualElements = [ 'HEAD', 'TITLE', 'BASE', 'LINK', 'STYLE', 'META', 'SCRIPT', 'NOSCRIPT' ];
 juiceClient.styleToAttribute = {
   'background-color': 'bgcolor',


### PR DESCRIPTION
Just noticed there was a duplicate `'TD'` in `juiceClient.tableElements`.