### PR TITLE
updated the example provided as was not clear.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To inline HTML without getting remote resources, using default options:
 
 ```js
 var juice = require('juice');
-var result = juice("<style>div{color:red;}</style><div/>");
+var result = juice("<style>div{color:red;}</style><div><div/>");
 ```
 
 result will be:


### PR DESCRIPTION
The example was not clear as is not opening the div, only was closing it. Even the result is correct, is not clear why the div opening tag is not appearing. 

So I added the <div> into the example