### PR TITLE
missing dom library reference in typescript definition

### DIFF
--- a/juice.d.ts
+++ b/juice.d.ts
@@ -2,6 +2,8 @@
 // Project: https://github.com/Automattic/juice
 // Definitions by: Kamil Nikel <https://github.com/knikel>
 
+/// <reference lib="dom" />
+
 /* =================== USAGE ===================
    import juice = require('juice');
    =============================================== */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,9 +1239,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -1285,9 +1285,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -2211,9 +2211,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "umd": {

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "deep-extend": "^0.6.0",
     "mensch": "^0.3.3",
     "slick": "^1.12.2",
-    "web-resource-inliner": "^4.3.1"
+    "web-resource-inliner": "=4.3.1"
   },
   "devDependencies": {
     "batch": "0.5.3",
     "browserify": "^16.2.3",
     "mocha": "^5.2.0",
     "should": "^11.1.1",
-    "typescript": "^2.9.1"
+    "typescript": "^3.6.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
```
node_modules/juice/juice.d.ts:32:29 - error TS2304: Cannot find name 'HTMLElement'.

32   export let widthElements: HTMLElement[];
                               ~~~~~~~~~~~
```

There should be a reference to `dom` library in typescript definition to use `HTMLElement`.

Also triple-slash directives was introduced in 3.0, so I updated `typescript`.

Also there is a problem with latest web-resource-inliner, it uses async that can't run on nodejs 4, so I downgraded it (there were no package-lock.json in nodejs 4 so the latest version was installed)