### PR TITLE
deps: bump mensch to fix mem leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commander": "^2.15.1",
     "cross-spawn": "^6.0.5",
     "deep-extend": "^0.6.0",
-    "mensch": "^0.3.3",
+    "mensch": "^0.3.4",
     "slick": "^1.12.2",
     "web-resource-inliner": "^4.3.1"
   },


### PR DESCRIPTION
Bumps the mensch CSS parser to fix a memory leak in the stringify function of version 0.3.3.

See https://github.com/brettstimmerman/mensch/issues/25 for more information.