### PR TITLE
Move cross-spawn to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "commander": "^2.15.1",
-    "cross-spawn": "^6.0.5",
     "deep-extend": "^0.6.0",
     "mensch": "^0.3.4",
     "slick": "^1.12.2",
@@ -39,6 +38,7 @@
   "devDependencies": {
     "batch": "0.5.3",
     "browserify": "^16.2.3",
+    "cross-spawn": "^6.0.5",
     "mocha": "^5.2.0",
     "should": "^11.1.1",
     "typescript": "^2.9.1"


### PR DESCRIPTION
It's only used in test/cli.js module.