### PR TITLE
Drop unused cssmin and uglify options from cli

### DIFF
--- a/juice.d.ts
+++ b/juice.d.ts
@@ -60,7 +60,6 @@ declare namespace juice {
     links?: boolean | number;
     relativeTo?: string;
     rebaseRelativeTo?: string;
-    cssmin?: boolean;
     strict?: boolean;
   }
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -109,16 +109,6 @@ cli.options = {
     pMap: 'webResourcesRebaseRelativeTo',
     map: 'rebaseRelativeTo',
     def: 'see docs for web-resource-inliner rebaseRelativeTo' },
-  'web-resources-cssmin': {
-    pMap: 'webResourcesCssmin',
-    map: 'cssmin',
-    def: 'see docs for web-resource-inliner cssmin',
-    coercion: JSON.parse },
-  'web-resources-uglify': {
-    pMap: 'webResourcesUglify',
-    map: 'uglify',
-    def: 'see docs for web-resource-inliner uglify',
-    coercion: JSON.parse },
   'web-resources-strict': {
     pMap: 'webResourcesStrict',
     map: 'strict',

--- a/test/cli.js
+++ b/test/cli.js
@@ -32,8 +32,6 @@ it('cli parses options', function(done) {
   assert.strictEqual(cli.argsToOptions({'webResourcesScripts': '24'}).webResources.scripts, 24);
   assert.strictEqual(cli.argsToOptions({'webResourcesRelativeTo': 'web'}).webResources.relativeTo, 'web');
   assert.strictEqual(cli.argsToOptions({'webResourcesRebaseRelativeTo': 'root'}).webResources.rebaseRelativeTo, 'root');
-  assert.strictEqual(cli.argsToOptions({'webResourcesCssmin': 'true'}).webResources.cssmin, true);
-  assert.strictEqual(cli.argsToOptions({'webResourcesUglify': 'true'}).webResources.uglify, true);
   assert.strictEqual(cli.argsToOptions({'webResourcesStrict': 'true'}).webResources.strict, true);
   done();
 });

--- a/test/typescript/juice-tests.ts
+++ b/test/typescript/juice-tests.ts
@@ -42,7 +42,6 @@ const allWebResourceOptions = {
     links: true,
     relativeTo: 'https://github.com/',
     rebaseRelativeTo: 'assets',
-    cssmin: true,
     strict: true,
   },
 };


### PR DESCRIPTION
I do not see these options are implemented in web-resource-inliner
or juice.