### PR TITLE
Replace deep-extend with nested Object.assign

### DIFF
--- a/bin/juice
+++ b/bin/juice
@@ -2,7 +2,6 @@
 
 var juice = require('..');
 var cli = require('../lib/cli');
-var xtend = require('deep-extend');
 var fs = require('fs');
 var path = require('path');
 
@@ -17,7 +16,13 @@ var queue = [];
 
 if (options.optionsFile) {
   var optionsFromFile = require(path.resolve(process.cwd(),options.optionsFile));
-  options = xtend({}, optionsFromFile, options);
+  options = Object.assign({}, optionsFromFile, options, {
+    webResources: Object.assign(
+      {},
+      optionsFromFile && optionsFromFile.webResources,
+      options && options.webResources
+    )
+  });
 }
 
 if (options.cssFile) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -714,11 +714,6 @@
         "ms": "2.0.0"
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "commander": "^2.15.1",
-    "deep-extend": "^0.6.0",
     "mensch": "^0.3.4",
     "slick": "^1.12.2",
     "web-resource-inliner": "^4.3.3"


### PR DESCRIPTION
deep-extend is only used to handle one nested options object.
In this diff I replaced dependency with native Object.assign and handled
"webResources" as special case similar to special case in cli options
definitions.