### PR TITLE
Replace custom extend utility with native Object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function juiceFile(filePath, options, callback) {
 }
 
 function inlineExternal(html, inlineOptions, callback) {
-  var options = utils.extend({fileContent: html}, inlineOptions);
+  var options = Object.assign({fileContent: html}, inlineOptions);
   inline.html(options, callback);
 }
 

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -7,7 +7,7 @@ var cheerio = require('cheerio');
 var utils = require('./utils');
 
 var cheerioLoad = function(html, options, encodeEntities) {
-  options = utils.extend({decodeEntities: false}, options || {});
+  options = Object.assign({decodeEntities: false}, options);
   html = encodeEntities(html);
   return cheerio.load(html,options);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@
  */
 
 var mensch = require('mensch');
-var own = {}.hasOwnProperty;
 var Selector = require('./selector');
 var Property = require('./property');
 
@@ -146,17 +145,8 @@ exports.compare = function(a, b) {
   return exports.compareFunc(a, b) == 1 ? a : b;
 };
 
-exports.extend = function(obj, src) {
-  for (var key in src) {
-    if (own.call(src, key)) {
-      obj[key] = src[key];
-    }
-  }
-  return obj;
-};
-
 exports.getDefaultOptions = function(options) {
-  var result = exports.extend({
+  var result = Object.assign({
     extraCss: '',
     insertPreservedExtraCss: true,
     applyStyleTags: true,


### PR DESCRIPTION
No need to implement this utility or choose the library in every
project.