### PR TITLE
juice.codeBlocks does not get removed by webpack

### DIFF
--- a/client.js
+++ b/client.js
@@ -24,4 +24,6 @@ juiceClient.inlineContent = function(html, css, options) {
   return cheerio(html, { xmlMode: options && options.xmlMode}, juiceClient.inlineDocument, [css, options]);
 };
 
+juiceClient.codeBlocks = cheerio.codeBlocks;
+
 module.exports = juiceClient;

--- a/index.js
+++ b/index.js
@@ -21,21 +21,9 @@ juice.Selector = utils.Selector;
 juice.Property = utils.Property;
 juice.utils = utils;
 
-juice.ignoredPseudos = juiceClient.ignoredPseudos;
-juice.widthElements = juiceClient.widthElements;
-juice.tableElements = juiceClient.tableElements;
-juice.nonVisualElements = juiceClient.nonVisualElements;
-juice.styleToAttribute = juiceClient.styleToAttribute;
-
-juice.juiceDocument = juiceClient.juiceDocument;
-juice.inlineDocument = juiceClient.inlineDocument;
-juice.inlineContent = juiceClient.inlineContent;
-
 juice.juiceFile = juiceFile;
 juice.juiceResources = juiceResources;
 juice.inlineExternal = inlineExternal;
-
-juice.codeBlocks = cheerio.codeBlocks;
 
 function juiceFile(filePath, options, callback) {
   // set default options


### PR DESCRIPTION
Hello!

**Summary**

Set `juiceClient.codeBlocks = cheerio.codeBlocks` in `/lib/client.js` instead of `/index.js` so that it gets emitted by webpack. I also removed some assignments in `/index.js` that should already exist because `juice = juiceClient`.

**Motivation**

Webpack does not emit `juice.codeBlocks = juiceClient.codeBlocks` (or any of the other assignments in `/index.js`). This breaks `codeBlocks` when using juice in the browser via `mjml-browser` (see https://github.com/mjmlio/mjml/issues/2653). Assigning `codeBlocks` in `/lib/client.js` instead of `/index.js` fixes the issue when testing locally via `npm link`.

Thanks for considering my PR!