### PR TITLE
Fixed counter-reset not working in combination with inline styles

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -124,6 +124,12 @@ function inlineDocument($, css, options) {
         return;
       }
 
+      if (!el.counterProps) {
+        el.counterProps = el.parent && el.parent.counterProps
+          ? Object.create(el.parent.counterProps)
+          : {};
+      }
+
       if (pseudoElementType) {
         var pseudoElPropName = 'pseudo' + pseudoElementType;
         var pseudoEl = el[pseudoElPropName];
@@ -148,12 +154,6 @@ function inlineDocument($, css, options) {
 
         // store reference to an element we need to compile style="" attr for
         editedElements.push(el);
-      }
-
-      if (!el.counterProps) {
-        el.counterProps = el.parent && el.parent.counterProps
-          ? Object.create(el.parent.counterProps)
-          : {};
       }
 
       function resetCounter(el, value) {

--- a/test/cases/juice-content/counter-reset.html
+++ b/test/cases/juice-content/counter-reset.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+      <style>
+        p {
+          color: red;
+        }
+      </style>
+  </head>
+  <body>
+    <p style="counter-reset: li;">Cool!</p>
+  </body>
+</html>

--- a/test/cases/juice-content/counter-reset.json
+++ b/test/cases/juice-content/counter-reset.json
@@ -1,0 +1,4 @@
+{
+  "removeStyleTags": true,
+  "inlinePseudoElements": true
+}

--- a/test/cases/juice-content/counter-reset.out
+++ b/test/cases/juice-content/counter-reset.out
@@ -1,0 +1,8 @@
+<html>
+  <head>
+      
+  </head>
+  <body>
+    <p style="color: red; counter-reset: li;">Cool!</p>
+  </body>
+</html>


### PR DESCRIPTION
An error is thrown in `resetCounter` when adding an `counter-reset` inline style to an element in combination with a different style (e.g., in head).

```
  1) juice-content/counter-reset:
     Uncaught TypeError: Cannot set properties of undefined (setting 'li')
      at resetCounter (lib/inline.js:167:40)
      at addProps (lib/inline.js:198:15)
      at Element.<anonymous> (lib/inline.js:146:11)
      at LoadedCheerio.each (node_modules/cheerio/lib/api/traversing.js:519:26)
      at handleRule (lib/inline.js:120:9)
      at Array.forEach (<anonymous>)
      at inlineDocument (lib/inline.js:36:9)
      at juiceDocument (lib/inline.js:459:3)
      at module.exports (lib/cheerio.js:61:22)
      at onInline (index.js:63:7)
      at /Users/.../juice/node_modules/web-resource-inliner/src/html.js:281:13
```

This error is caused by the fact that the `addProps` method is called when an element doesn't have `styleProps` (in the `if (!el.styleProps) {` block), before a default value for `counterProps` is set. This is fixed by assigning a default value for `counterProps` before calling `addProps`.

A test case is also added to reproduce the issue and to prevent future regressions.