### PR TITLE
fix: pin cheerio to latest rc.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "commander": "^6.1.0",
         "mensch": "^0.3.4",
         "slick": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "commander": "^6.1.0",
     "mensch": "^0.3.4",
     "slick": "^1.12.2",


### PR DESCRIPTION
Fixes issues with breaking changes from `cheerio@1.0.0` until it's handled somehow upstream.

See [discussion](https://github.com/cheeriojs/cheerio/issues/3993) for more info.