### PR TITLE
Fix #482: "Error when encoded quotes are used in html attribute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ All juice methods take an options object that can contain any of these propertie
 
 * `applyWidthAttributes` - whether to use any CSS pixel widths to create `width` attributes on elements set in `juice.widthElements`. Defaults to `true`.
 
+* `decodeStyleAttributes` - whether to decode the value of `style=` attributes. Defaults to `false`.
+
 * `extraCss` - extra css to apply to the file. Defaults to `""`.
 
 * `insertPreservedExtraCss` - whether to insert into the document any preserved `@media` or `@font-face` content from `extraCss` when using `preserveMediaQueries`, `preserveFontFaces` or `preserveKeyFrames`. When `true` order of preference to append the `<style>` element is into `head`, then `body`, then at the end of the document. When a `string` the value is treated as a CSS/jQuery/cheerio selector, and when found, the `<style>` tag will be appended to the end of the first match. Defaults to `true`.

--- a/juice.d.ts
+++ b/juice.d.ts
@@ -50,6 +50,7 @@ declare namespace juice {
     xmlMode?: boolean;
     preserveImportant?: boolean;
     resolveCSSVariables?: boolean;
+    decodeStyleAttributes?: boolean;
   }
 
   interface WebResourcesOptions {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -118,6 +118,10 @@ cli.options = {
     pMap: 'webResourcesStrict',
     map: 'strict',
     def: 'see docs for web-resource-inliner strict',
+    coercion: JSON.parse },
+  'decode-style-attributes': {
+    pMap: 'decodeStyleAttributes',
+    def: 'decode the value of `style=` attributes?',
     coercion: JSON.parse }
 };
 

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var { decode } = require('entities');
+
 var utils = require('./utils');
 var numbers = require('./numbers');
 var variables = require('./variables');
@@ -149,7 +151,11 @@ function inlineDocument($, css, options) {
 
         // if the element has inline styles, fake selector with topmost specificity
         if ($(el).attr(styleAttributeName)) {
-          var cssText = '* { ' + $(el).attr(styleAttributeName) + ' } ';
+          var styleAttributeValue = $(el).attr(styleAttributeName);
+          var cssStyleAttributeValue = options.decodeStyleAttributes
+            ? decode(styleAttributeValue)
+            : styleAttributeValue;
+          var cssText = '* { ' + cssStyleAttributeValue + ' } ';
           addProps(utils.parseCSS(cssText)[0][1], new utils.Selector('<style>', true));
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cheerio": "^1.0.0",
         "commander": "^12.1.0",
+        "entities": "^4.5.0",
         "mensch": "^0.3.4",
         "slick": "^1.12.2",
         "web-resource-inliner": "^7.0.0"
@@ -1151,7 +1152,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "cheerio": "^1.0.0",
     "commander": "^12.1.0",
+    "entities": "^4.5.0",
     "mensch": "^0.3.4",
     "slick": "^1.12.2",
     "web-resource-inliner": "^7.0.0"

--- a/test/cli.js
+++ b/test/cli.js
@@ -27,6 +27,7 @@ it('cli parses options', function(done) {
   assert.strictEqual(parseArgs({'applyAttributesTableElements': 'true'}).applyAttributesTableElements, true);
   assert.strictEqual(parseArgs({'xmlMode': 'true'}).xmlMode, true);
   assert.strictEqual(parseArgs({'resolveCSSVariables': 'true'}).resolveCSSVariables, true);
+  assert.strictEqual(parseArgs({'decodeStyleAttributes': 'true'}).decodeStyleAttributes, true);
   assert.strictEqual(parseArgs({'webResourcesInlineAttribute': 'true'}).webResources.inlineAttribute, true);
   assert.strictEqual(parseArgs({'webResourcesImages': '12'}).webResources.images, 12);
   assert.strictEqual(parseArgs({'webResourcesLinks': 'true'}).webResources.links, true);

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -192,3 +192,21 @@ it('test that preserved text order is stable', function() {
       utils.getPreservedText('div { color: red; } @media (min-width: 320px) { div { color: green; } } @media (max-width: 640px) { div { color: blue; } }', { mediaQueries: true }, juice.ignoredPseudos).replace(/\s+/g, ' '),
       ' @media (min-width: 320px) { div { color: green; } } @media (max-width: 640px) { div { color: blue; } } ');
 });
+
+it('can handle style attributes with html entities', function () {
+  // Throws without decodeStyleAttributes: true
+  assert.throws(function () {
+    juice(
+      '<style type="text/css">div {color: red;}</style><div style="font-family:&quot;Open Sans&quot;, sans-serif;"></div>'
+    );
+  });
+
+  // Expected results with decodeStyleAttributes: true
+  assert.deepEqual(
+    juice(
+      '<style type="text/css">div {color: red;}</style><div style="font-family:&quot;Open Sans&quot;, sans-serif;"></div>',
+      { decodeStyleAttributes: true }
+    ),
+    "<div style=\"color: red; font-family: 'Open Sans', sans-serif;\"></div>"
+  );
+});


### PR DESCRIPTION
Fix #482 

This PR adds an option to decode HTML entities in the style attribute before it is handed off to mensch for parsing. The problem is that although HTML entities are valid in `style` attribute values, they are not valid in CSS strings, resulting in a mensch parse that contains invalid properties/values, and ultimately causes juice to fail.  