### PR TITLE
Bump commander from 12.1.0 to 14.0.0

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,6 +18,10 @@ cli.getProgram = function() {
     program.option('--' + key + ' [value]', cli.options[key].def);
   });
 
+  // Commander.js 13.x: Excess command-arguments now cause an error unless explicitly allowed.
+  // In order to retain previous behaviour (accept extra command arguments), allow excess arguments.
+  program.allowExcessArguments();
+
   program.parse(process.argv);
 
   return program;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0",
-    "commander": "^12.1.0",
+    "commander": "^14.0.0",
     "entities": "^6.0.0",
     "mensch": "^0.3.4",
     "slick": "^1.12.2",


### PR DESCRIPTION
### Refine #541

The automatic update created by **\[Dependabot]** failed due to a **breaking change** introduced in [`commander.js` v13](https://github.com/tj/commander.js/blob/master/CHANGELOG.md#1300-2024-12-30).

This PR refines the update by adjusting our usage of `commander.js` to be compatible with the new version, ensuring the dependency bump can be applied safely.