### PR TITLE
feat: inline duplicate properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All Juice methods take an options object that can contain any of these propertie
 | `applyWidthAttributes` | `true` | Use any CSS pixel widths to create `width` attributes on elements set in `juice.widthElements`. |
 | `decodeStyleAttributes` | `false` | Decode the value of `style` attributes. |
 | `extraCss` | `""` | Extra CSS to apply to the file. |
+| `inlineDuplicateProperties` | `false` | When `true`, declarations with identical CSS properties will all be inlined, instead of only the one with the highest specificity. Useful for progressive enhancement. |
 | `insertPreservedExtraCss` | `true` | Whether to insert into the document any preserved `@media` or `@font-face` content from `extraCss` when using `preserveMediaQueries`, `preserveFontFaces` or `preserveKeyFrames`. <br><br> When set to `true`, order of preference to append the `<style>` element is into `head`, then `body`, then at the end of the document. <br><br> When a `string` the value is treated as a CSS/jQuery/cheerio selector, and when found, the `<style>` tag will be appended to the end of the first match. |
 | `inlinePseudoElements` | `false` | Insert pseudo elements (`::before` and `::after`) as `<span>` into the DOM. *Note*: Inserting pseudo elements will modify the DOM and may conflict with CSS selectors elsewhere on the page (e.g., `:last-child`). |
 | `preserveFontFaces` | `true` | Preserve all `@font-face` within `<style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. |

--- a/juice.d.ts
+++ b/juice.d.ts
@@ -51,6 +51,7 @@ declare namespace juice {
     preserveImportant?: boolean;
     resolveCSSVariables?: boolean;
     decodeStyleAttributes?: boolean;
+    inlineDuplicateProperties?: boolean;
   }
 
   interface WebResourcesOptions {

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -219,7 +219,26 @@ function inlineDocument($, css, options) {
 
             // if property name is not in the excluded properties array
             if (juiceClient.excludedProperties.indexOf(name) < 0) {
-              if (existing && existing.compare(prop) === prop || !existing) {
+              if (options.inlineDuplicateProperties) {
+                // When allowing duplicates, we need to track all properties
+                if (existing) {
+                  // Check if this is from the same selector as the existing property
+                  if (existing.selector === selector) {
+                    // Same selector: prepend to maintain declaration order (since we're building the chain in reverse)
+                    prop.nextProp = existing;
+                    el.styleProps[name] = prop;
+                  } else {
+                    // Different selector: append to end of chain to maintain specificity order
+                    var last = existing;
+                    while (last.nextProp) {
+                      last = last.nextProp;
+                    }
+                    last.nextProp = prop;
+                  }
+                } else {
+                  el.styleProps[name] = prop;
+                }
+              } else if (existing && existing.compare(prop) === prop || !existing) {
                 // deleting a property let us change the order (move it to the end in the setStyleAttrs loop)
                 if (existing && existing.selector !== selector) {
                   delete el.styleProps[name];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,6 +158,7 @@ exports.getDefaultOptions = function(options) {
     applyHeightAttributes: true,
     applyAttributesTableElements: true,
     resolveCSSVariables: true,
+    inlineDuplicateProperties: false,
     url: ''
   }, options);
 


### PR DESCRIPTION
This PR introduces a new option, `inlineDuplicateProperties`, which allows the user to choose whether Juice should inline the same property multiple times on the same element, instead of only inlining the winning/highest specificity selector.

This option is `false` by default, you need to opt-in to the functionality.

The use-case is particularly for HTML emails, where progressive enhancement is sometimes required because not all email clients support the same level of CSS features. For example, given this Tailwind CSS example:

```html
<div class="bg-black bg-black/50" />
```

... with `inlineDuplicateProperties: true` we can get this output:

```html
<div style="background-color: #000; background-color: rgba(0,0,0,0.5)" />
```

... which will show a solid black background color in clients such as Outlook on Windows, which do not support `rgba`.

---

Closes #380 