### PR TITLE
revert: selectors must match exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All Juice methods take an options object that can contain any of these propertie
 | `preserveMediaQueries` | `true` | Preserve all media queries (and contained styles) within `<style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. |
 | `preserveKeyFrames` | `true` | Preserve all key frames within `<style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. |
 | `preservePseudos` | `true` | Preserve all rules containing pseudo selectors defined in `ignoredPseudos` within `<style>` tags as a refinement when `removeStyleTags` is `true`. Other styles are removed. |
-| `preservedSelectors` | `[]` | Array of strings that represent CSS selectors to preserve inside `<style>` tags when `removeStyleTags` or `removeInlinedSelectors` are `true`. |
+| `preservedSelectors` | `[]` | Array of strings that represent CSS selectors to preserve inside `<style>` tags when `removeStyleTags` or `removeInlinedSelectors` are `true`. Matches substrings.
 | `removeInlinedSelectors` | `false` | Remove CSS rules from `<style>` tags after (possibly) inlining them. Other rules are preserved. Works only if `removeStyleTags` is `false`. |
 | `removeStyleTags` | `true` | Remove the original `<style>` tags after (possibly) inlining their CSS content. Overrides `removeInlinedSelectors`. | 
 | `resolveCSSVariables` | `true` | Resolve CSS variables. |

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,8 +294,12 @@ exports.matchesPreservedSelector = function(selector, preservedSelectors) {
   
   for (var i = 0; i < preservedSelectors.length; i++) {
     var pattern = preservedSelectors[i];
-    // Exact match only
+    // Exact match
     if (selector === pattern) {
+      return true;
+    }
+    // Check if pattern is a substring (for simple contains matching)
+    if (selector.indexOf(pattern) !== -1) {
       return true;
     }
   }

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -601,7 +601,7 @@ it('`preservedSelectors` option', function() {
     '<style>.important { font-weight: bold; } .another { text-decoration: underline; }</style> <div class="important" style="color: red; font-weight: bold;">Test</div>'
   );
 
-  // Email client targeting use case
+  // Email client targeting - include substring matches
   result = juice(
     `<style>
       p { color: black; } 
@@ -612,7 +612,7 @@ it('`preservedSelectors` option', function() {
     { 
       removeStyleTags: false, 
       removeInlinedSelectors: true, 
-      preservedSelectors: ['u + .body', '#outlook a'] 
+      preservedSelectors: ['body', '#outlook a']
     }
   );
 


### PR DESCRIPTION
Reverts exact matching for `preservedSelectors`, as substring matches can be useful to preserve selectors that may not be known upfront (i.e. when using a framework like Tailwind CSS).

Note: this is not glob matching, it only matches strings not glob patterns.