### PR TITLE
fix: apply default options consistently across all client functions

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -24,7 +24,7 @@ module.exports = function makeJuiceClient(juiceClient) {
   juiceClient.inlineDocument = inlineDocument;
 
   function inlineDocument($, css, options) {
-    options = options || {};
+    options = utils.getDefaultOptions(options);
     var rules = utils.parseCSS(css);
     var editedElements = [];
     var styleAttributeName = 'style';

--- a/test/cases/integration.out
+++ b/test/cases/integration.out
@@ -10,14 +10,14 @@
 <body bgcolor="#f6f6f6" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; height: 100%; width: 100%;">
 
 <!-- body -->
-<table class="body-wrap" bgcolor="#f6f6f6" style="margin: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%; padding: 20px;">
+<table class="body-wrap" bgcolor="#f6f6f6" style="margin: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%; padding: 20px;" width="100%">
 	<tr style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 		<td style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;"></td>
 		<td class="container" bgcolor="#FFFFFF" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; padding: 20px; border: 1px solid #f0f0f0; display: block; max-width: 600px; margin: 0 auto; clear: both;">
 
 			<!-- content -->
 			<div class="content" style="padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; max-width: 600px; margin: 0 auto; display: block;">
-			<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;">
+			<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;" width="100%">
 				<tr style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 					<td style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 						<p style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; line-height: 1.6; margin-bottom: 10px; font-weight: normal; font-size: 14px;">Hi there,</p>
@@ -26,7 +26,7 @@
 						<p style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; line-height: 1.6; margin-bottom: 10px; font-weight: normal; font-size: 14px;">This is a really simple email template. Its sole purpose is to get you to click the button below.</p>
 						<h2 style="padding: 0; font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif; color: #000; margin: 40px 0 10px; line-height: 1.2; font-weight: 200; font-size: 28px;">How do I use it?</h2>
 						<p style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; line-height: 1.6; margin-bottom: 10px; font-weight: normal; font-size: 14px;">All the information you need is on GitHub.</p>
-						<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;">
+						<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;" width="100%">
 							<tr style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 								<td class="padding" style="margin: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; padding: 10px 0;">
 									<p style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; line-height: 1.6; margin-bottom: 10px; font-weight: normal; font-size: 14px;"><a href="https://github.com/leemunroe/html-email-template" class="btn-primary" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; text-decoration: none; color: #FFF; background-color: #348eda; border: solid #348eda; border-width: 10px 20px; line-height: 2; font-weight: bold; margin-right: 10px; text-align: center; cursor: pointer; display: inline-block; border-radius: 25px;">View the source and instructions on GitHub</a></p>
@@ -49,14 +49,14 @@
 <!-- /body -->
 
 <!-- footer -->
-<table class="footer-wrap" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%; clear: both;">
+<table class="footer-wrap" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%; clear: both;" width="100%">
 	<tr style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 		<td style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;"></td>
 		<td class="container" style="padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; display: block; max-width: 600px; margin: 0 auto; clear: both;">
 
 			<!-- content -->
 			<div class="content" style="padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; max-width: 600px; margin: 0 auto; display: block;">
-				<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;">
+				<table style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; width: 100%;" width="100%">
 					<tr style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 						<td align="center" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">
 							<p style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; line-height: 1.6; margin-bottom: 10px; font-weight: normal; font-size: 12px; color: #666;">Don't like these annoying emails? <a href="#" style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6; color: #999;"><unsubscribe style="margin: 0; padding: 0; font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6;">Unsubscribe</unsubscribe></a>.

--- a/test/cli.js
+++ b/test/cli.js
@@ -62,7 +62,7 @@ it('cli css included', function(done) {
   var expectedPath = 'test/cases/integration.out';
   var outputPath = 'tmp/integration.out';
 
-  var juiceProcess = spawn('bin/juice', [htmlPath, '--css', cssPath, '--apply-width-attributes', 'false', outputPath]);
+  var juiceProcess = spawn('bin/juice', [htmlPath, '--css', cssPath, outputPath]);
 
   juiceProcess.on('error', done);
 


### PR DESCRIPTION
## Problem
The `inlineContent` and `inlineDocument` functions were not applying default options correctly. This meant that when users called `juice.inlineContent(html, css)` or `juice.inlineContent(html, css, {})`, for example, they wouldn't get expected default behaviors defined in [`lib/utils.js`](https://github.com/Automattic/juice/blob/6328895f2793c59dbe40319419b64d54df81808e/lib/utils.js#L396).

## Solution
Modified `inlineDocument` to call [`utils.getDefaultOptions(options)`](https://github.com/Automattic/juice/blob/6328895f2793c59dbe40319419b64d54df81808e/lib/utils.js#L396), ensuring all client entry points properly merge provided options with defaults. This makes the behavior consistent with `juiceDocument` which already applied defaults [here](https://github.com/Automattic/juice/blob/6328895f2793c59dbe40319419b64d54df81808e/lib/inline.js#L492-L493).

### Breaking changes
If you need the old behavior (no defaults applied), explicitly pass options to disable all truthy defaults:
```javascript
juice.inlineContent(html, css, {
  insertPreservedExtraCss: false,
  applyStyleTags: false,
  removeStyleTags: false,
  preserveMediaQueries: false,
  preserveFontFaces: false,
  preserveKeyFrames: false,
  preservePseudos: false,
  applyWidthAttributes: false,
  applyHeightAttributes: false,
  applyAttributesTableElements: false,
  resolveCSSVariables: false
});
```
as well as for `inlineDocument`.