### PR TITLE
feat: add data-juice-important attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,20 @@ Override the [`inlineDuplicateProperties`](#options) option for a single element
 
 The `data-juice-duplicates` attribute is removed from the output HTML.
 
+#### data-juice-important
+
+Override the [`preserveImportant`](#options) option for a single element by adding `data-juice-important` to it. The attribute presence (or `data-juice-important="true"`) preserves `!important` in that element's inlined declarations; `data-juice-important="false"` strips it:
+
+```html
+<!-- keeps !important in the inlined style, even if the option is off -->
+<div class="cta" data-juice-important></div>
+
+<!-- strips !important from the inlined style, even if the option is on -->
+<div class="cta" data-juice-important="false"></div>
+```
+
+The `data-juice-important` attribute is removed from the output HTML.
+
 ### Ignoring CSS with comments
 
 You can use special CSS comments to prevent Juice from inlining entire CSS files, rules, or even just declarations.

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -93,6 +93,15 @@ export default function makeJuiceClient(juiceClient) {
           allowDuplicates = duplicatesAttr !== 'false';
         }
 
+        // per-element override of options.preserveImportant via the
+        // data-juice-important attribute. Presence (or "true") preserves
+        // !important for this element; "false" strips it.
+        let preserveImportant = options.preserveImportant;
+        const importantAttr = $(el).attr('data-juice-important');
+        if (importantAttr !== undefined) {
+          preserveImportant = importantAttr !== 'false';
+        }
+
         if (!el.counterProps) {
           el.counterProps = el.parent && el.parent.counterProps
             ? Object.create(el.parent.counterProps)
@@ -114,6 +123,7 @@ export default function makeJuiceClient(juiceClient) {
 
         if (!el.styleProps) {
           el.styleProps = {};
+          el.preserveImportant = preserveImportant;
 
           // if the element has inline styles, fake selector with topmost specificity
           if ($(el).attr(styleAttributeName)) {
@@ -176,7 +186,7 @@ export default function makeJuiceClient(juiceClient) {
               }
 
               const important = value.match(/!important$/) !== null;
-              if (important && !options.preserveImportant) value = removeImportant(value);
+              if (important && !preserveImportant) value = removeImportant(value);
               // adds line number and column number for the properties as "additionalPriority" to the
               // properties because in CSS the position directly affect the priority.
               const additionalPriority = [style[i].position.start.line, style[i].position.start.col];
@@ -295,7 +305,7 @@ export default function makeJuiceClient(juiceClient) {
         for (const i in el.styleProps) {
           if (el.styleProps[i].prop === dimension) {
             let value = el.styleProps[i].value;
-            if (options.preserveImportant) {
+            if (el.preserveImportant) {
               value = removeImportant(value);
             }
             if (value.match(/(px|auto)/)) {
@@ -328,7 +338,7 @@ export default function makeJuiceClient(juiceClient) {
           if (styleProps.indexOf(el.styleProps[i].prop) > -1) {
             const prop = juiceClient.styleToAttribute[el.styleProps[i].prop];
             let value = el.styleProps[i].value;
-            if (options.preserveImportant) {
+            if (el.preserveImportant) {
               value = removeImportant(value);
             }
             if (prop === 'background') {
@@ -347,6 +357,9 @@ export default function makeJuiceClient(juiceClient) {
 
     // data-juice-duplicates is a juice control attribute; strip it from output.
     $('[data-juice-duplicates]').removeAttr('data-juice-duplicates');
+
+    // data-juice-important is a juice control attribute; strip it from output.
+    $('[data-juice-important]').removeAttr('data-juice-important');
 
     editedElements.forEach(setStyleAttrs);
 

--- a/test/juice.test.js
+++ b/test/juice.test.js
@@ -283,6 +283,30 @@ it('data-juice-duplicates', function() {
   ).toBe('<div></div>');
 });
 
+it('data-juice-important', function() {
+  const css = '.test { color: red !important; }';
+
+  // attribute present (no value) preserves !important even when the option is off
+  expect(
+    juice.inlineContent('<div class="test" data-juice-important></div>', css)
+  ).toBe('<div class="test" style="color: red !important;"></div>');
+
+  // data-juice-important="true" preserves !important
+  expect(
+    juice.inlineContent('<div class="test" data-juice-important="true"></div>', css)
+  ).toBe('<div class="test" style="color: red !important;"></div>');
+
+  // data-juice-important="false" strips !important even when the option is on
+  expect(
+    juice.inlineContent('<div class="test" data-juice-important="false"></div>', css, { preserveImportant: true })
+  ).toBe('<div class="test" style="color: red;"></div>');
+
+  // the attribute is stripped from output regardless of whether it matched a rule
+  expect(
+    juice.inlineContent('<div data-juice-important></div>', 'span { color: red; }')
+  ).toBe('<div></div>');
+});
+
 it('removeInlinedSelectors', function() {
   // Basic test - inlined selectors should be removed, media queries preserved
   let result = juice(


### PR DESCRIPTION
## Summary

Adds a per-element `data-juice-important` attribute that overrides the global `preserveImportant` option for a single element.

- Attribute present (or `="true"`) preserves `!important` in that element's inlined declarations, even when the option is off
- `="false"` strips `!important`, even when the option is on
- The attribute is removed from the output HTML

Mirrors the existing `data-juice-duplicates` pattern.

## Changes

- `lib/inline.js`: resolve the per-element value, store it on the element so the table/dimension attribute helpers respect it too, and strip the attribute from output
- `test/juice.test.js`: covers presence, `="true"`, `="false"` overriding the option, and attribute removal
- `README.md`: documented under Special markup